### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.*
       - name: Install dependencies
-        run: dotnet restore -p:NuGetBuild=True
+        run: dotnet restore -p:NuGetBuild=True -p:LangVersion=Latest
       - name: Build
         run: dotnet build --configuration Release --no-restore  -p:NuGetBuild=True
-      - name: Test
-        run: dotnet test --no-restore  -p:NuGetBuild=True

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   workflow_call:
-    with: 
+    inputs: 
       project:
         required: false
         type: string

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,6 @@ name: build
 
 on:
   workflow_call:
-    inputs: 
-      project:
-        required: false
-        type: string
 
 jobs:
   build:
@@ -16,8 +12,8 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
       - name: Install dependencies
-        run: dotnet restore ${{ inputs.project }}
+        run: dotnet restore -p:NuGetBuild=True
       - name: Build
-        run: dotnet build ${{ inputs.project }} --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore  -p:NuGetBuild=True
       - name: Test
-        run: dotnet test ${{ inputs.project }} --no-restore
+        run: dotnet test --no-restore  -p:NuGetBuild=True

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           dotnet-version: 5.0.*
       - name: Install dependencies
-        run: dotnet restore -p:NuGetBuild=True -p:LangVersion=Latest
+        run: dotnet restore -p:NuGetBuild=True
       - name: Build
-        run: dotnet build --configuration Release --no-restore  -p:NuGetBuild=True
+        run: dotnet build --configuration Release --no-restore  -p:NuGetBuild=True -p:LangVersion=Latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: build
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: build
 
 on:
   workflow_call:
+    with: 
+      project:
+        required: false
+        type: string
 
 jobs:
   build:
@@ -12,8 +16,8 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore ${{ inputs.project }}
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build ${{ inputs.project }} --configuration Release --no-restore
       - name: Test
-        run: dotnet test --no-restore
+        run: dotnet test ${{ inputs.project }} --no-restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false 
       - name: Push with dotnet
-        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source {{ inputs.source }} --skip-duplicate
+        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source ${{ inputs.source }} --skip-duplicate
       - name: Archive artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ name: publish
 on:
   workflow_call:
     inputs: 
-      project:
-        required: false
-        type: string
       source:
         required: true
         type: string
@@ -27,13 +24,13 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
       - name: Install dependencies
-        run: dotnet restore ${{ inputs.project }}
+        run: dotnet restore
       - name: Build
-        run: dotnet build ${{ inputs.project }} --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore -p:NuGetBuild=True
       - name: Test
-        run: dotnet test ${{ inputs.project }} --no-restore
+        run: dotnet test --no-restore  -p:NuGetBuild=True
       - name: Pack
-        run: dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false 
+        run: dotnet pack --output artifacts --configuration Release --no-restore --no-build  -p:NuGetBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false 
       - name: Push with dotnet
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source ${{ inputs.source }} --skip-duplicate
       - name: Archive artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Get the version
         id: get_version
         run: |
-          VERSION="${{ inputs.version}}"
+          echo ${{ inputs.version }}
+          VERSION="${{ inputs.version }}"
           VERSION="${version//v}"
           echo VERSION:${VERSION}
           echo ::set-output name=VERSION::${VERSION}      

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           echo "VERSION $VERSION"       
           dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=$VERSION -p:TreatWarningsAsErrors=false 
       - name: Push with dotnet
-        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json --skip-duplicate
       - name: Archive artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Get the version
+        id: get_version
+        run: |
+          VERSION="${{ inputs.version}}"
+          VERSION="${version//v}"
+          echo VERSION:${VERSION}
+          echo ::set-output name=VERSION::${VERSION}      
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
       - name: Install dependencies
@@ -27,7 +34,7 @@ jobs:
       - name: Test
         run: dotnet test ${{ inputs.project }} --no-restore
       - name: Pack
-        run: dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ inputs.version:1 }} -p:TreatWarningsAsErrors=false 
+        run: dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false 
       - name: Push with dotnet
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json --skip-duplicate
       - name: Archive artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ on:
       version:
         required: true
         type: string
+      source:
+        required: true
+        type: string
     secrets:
       apikey:
         required: true
@@ -37,7 +40,7 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false 
       - name: Push with dotnet
-        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json --skip-duplicate
+        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source {{ inputs.source }} --skip-duplicate
       - name: Archive artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: dotnet test ${{ inputs.project }} --no-restore
       - name: Pack
         run: |
-          echo "input ref { $inputs.ref }}"
+          echo "input ref ${{ inputs.ref }}"
           arrTag=(${inputs.ref//\// })
           VERSION="${arrTag[2]}"
           VERSION="${VERSION:1}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo ${{ inputs.version }}
           VERSION="${{ inputs.version }}"
-          VERSION="${version//v}"
+          VERSION="${VERSION//v}"
           echo VERSION:${VERSION}
           echo ::set-output name=VERSION::${VERSION}      
       - name: Setup .NET Core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore -p:NuGetBuild=True
       - name: Build
         run: dotnet build --configuration Release --no-restore -p:NuGetBuild=True
       - name: Test
-        run: dotnet test --no-restore  -p:NuGetBuild=True
+        run: dotnet test --no-restore -p:NuGetBuild=True
       - name: Pack
         run: dotnet pack --output artifacts --configuration Release --no-restore --no-build  -p:NuGetBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false 
       - name: Push with dotnet

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: publish
+
+on:
+  workflow_call:
+    inputs: 
+      project:
+        required: false
+        type: string
+      ref:
+        required: true
+        type: string
+    secrets:
+      apikey:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+      - name: Install dependencies
+        run: dotnet restore ${{ inputs.project }}
+      - name: Build
+        run: dotnet build ${{ inputs.project }} --configuration Release --no-restore
+      - name: Test
+        run: dotnet test ${{ inputs.project }} --no-restore
+      - name: Pack
+        run: |
+          arrTag=(${inputs.ref//\// })
+          VERSION="${arrTag[2]}"
+          VERSION="${VERSION:1}"
+          echo "VERSION $VERSION"       
+          dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=$VERSION -p:TreatWarningsAsErrors=false 
+      - name: Push with dotnet
+        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts          

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,13 @@ jobs:
     steps:
       - name: Dump environment variables
         id: dump_environment_variables
-        run: printenv      
+        run: |
+          printenv 
+          echo ${{ inputs.source }}
+      - name: if source
+        id: if-source     
+        if: ${{ inputs.source == '' }}
+        run: echo "no source"
       - name: Get the version
         id: get_version
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       project:
         required: false
         type: string
-      ref:
+      version:
         required: true
         type: string
     secrets:
@@ -27,13 +27,7 @@ jobs:
       - name: Test
         run: dotnet test ${{ inputs.project }} --no-restore
       - name: Pack
-        run: |
-          echo "input ref ${{ inputs.ref }}"
-          arrTag=(${inputs.ref//\// })
-          VERSION="${arrTag[2]}"
-          VERSION="${VERSION:1}"
-          echo "VERSION $VERSION"       
-          dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=$VERSION -p:TreatWarningsAsErrors=false 
+        run: dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ inputs.version }} -p:TreatWarningsAsErrors=false 
       - name: Push with dotnet
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json --skip-duplicate
       - name: Archive artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Test
         run: dotnet test ${{ inputs.project }} --no-restore
       - name: Pack
-        run: dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ inputs.version }} -p:TreatWarningsAsErrors=false 
+        run: dotnet pack ${{ inputs.project }} --output artifacts --configuration Release --no-restore --no-build -p:Version=${{ inputs.version:1 }} -p:TreatWarningsAsErrors=false 
       - name: Push with dotnet
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json --skip-duplicate
       - name: Archive artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,11 @@ jobs:
         with:
           dotnet-version: 5.0.*
       - name: Install dependencies
-        run: dotnet restore -p:NuGetBuild=True -p:LangVersion=Latest
+        run: dotnet restore -p:NuGetBuild=True
       - name: Build
         run: dotnet build --configuration Release --no-restore -p:NuGetBuild=True -p:LangVersion=Latest
       - name: Pack
-        run: dotnet pack --output artifacts --configuration Release --no-restore --no-build  -p:NuGetBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }} -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true -p:LangVersion=Latest
+        run: dotnet pack --output artifacts --configuration Release --no-restore --no-build  -p:NuGetBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }} -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true
       - name: Push with dotnet
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source ${{ steps.sourceeval.outputs.value }} --skip-duplicate
       - name: Archive artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,8 @@ jobs:
         run: dotnet test ${{ inputs.project }} --no-restore
       - name: Pack
         run: |
-          arrTag=(${inputs.ref//\// })
+          echo "input ref { $inputs.ref }}"
+          arrTag=(${{inputs.ref//\// }})
           VERSION="${arrTag[2]}"
           VERSION="${VERSION:1}"
           echo "VERSION $VERSION"       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs: 
       source:
-        required: true
+        required: false
         type: string
     secrets:
       apikey:
@@ -14,27 +14,30 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Dump environment variables
+        id: dump_environment_variables
+        run: printenv      
       - name: Get the version
         id: get_version
         run: |
           VERSION="${GITHUB_REF_NAME//v}"
           echo VERSION:${VERSION}
-          echo ::set-output name=VERSION::${VERSION}  
-      - uses: actions/checkout@v2    
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
-      - name: Install dependencies
-        run: dotnet restore -p:NuGetBuild=True
-      - name: Build
-        run: dotnet build --configuration Release --no-restore -p:NuGetBuild=True
-      - name: Test
-        run: dotnet test --no-restore -p:NuGetBuild=True
-      - name: Pack
-        run: dotnet pack --output artifacts --configuration Release --no-restore --no-build  -p:NuGetBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false 
-      - name: Push with dotnet
-        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source ${{ inputs.source }} --skip-duplicate
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: artifacts
-          path: artifacts          
+          echo ::set-output name=VERSION::${VERSION}         
+      # - uses: actions/checkout@v2    
+      # - name: Setup .NET Core
+      #   uses: actions/setup-dotnet@v1
+      #   with:
+      #     dotnet-version: 5.0.*
+      # - name: Install dependencies
+      #   run: dotnet restore -p:NuGetBuild=True -p:LangVersion=Latest
+      # - name: Build
+      #   run: dotnet build --configuration Release --no-restore -p:NuGetBuild=True -p:LangVersion=Latest
+      # - name: Pack
+      #   run: dotnet pack --output artifacts --configuration Release --no-restore --no-build  -p:NuGetBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }} -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true -p:LangVersion=Latest
+      # - name: Push with dotnet
+      #   run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source ${{ inputs.source }} --skip-duplicate
+      # - name: Archive artifacts
+      #   uses: actions/upload-artifact@v1
+      #   with:
+      #     name: artifacts
+      #     path: artifacts          

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Get the version
         id: get_version
         run: |
           VERSION="${GITHUB_REF_NAME//v}"
           echo VERSION:${VERSION}
-          echo ::set-output name=VERSION::${VERSION}      
+          echo ::set-output name=VERSION::${VERSION}  
+      - uses: actions/checkout@v2    
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Pack
         run: |
           echo "input ref { $inputs.ref }}"
-          arrTag=(${{inputs.ref//\// }})
+          arrTag=(${inputs.ref//\// })
           VERSION="${arrTag[2]}"
           VERSION="${VERSION:1}"
           echo "VERSION $VERSION"       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,6 @@ on:
       project:
         required: false
         type: string
-      version:
-        required: true
-        type: string
       source:
         required: true
         type: string
@@ -24,9 +21,7 @@ jobs:
       - name: Get the version
         id: get_version
         run: |
-          echo ${{ inputs.version }}
-          VERSION="${{ inputs.version }}"
-          VERSION="${VERSION//v}"
+          VERSION="${GITHUB_REF_NAME//v}"
           echo VERSION:${VERSION}
           echo ::set-output name=VERSION::${VERSION}      
       - name: Setup .NET Core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,36 +14,36 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump environment variables
-        id: dump_environment_variables
-        run: |
-          printenv 
-          echo ${{ inputs.source }}
-      - name: if source
-        id: if-source     
-        if: ${{ inputs.source == '' }}
-        run: echo "no source"
+      - uses: haya14busa/action-cond@v1
+        id: sourceeval
+        with:
+          cond: ${{ inputs.source == '' }}
+          # default nuget source. TODO change to nuget.org
+          if_true: "https://nuget.cloudsmith.io/lombiq/open-source-orchard-core-extensions/v3/index.json"
+          if_false: "${{ inputs.source == '' }}"
+      - name: Print source
+        run: echo Nuget Source:${{ steps.sourceeval.outputs.value }}
       - name: Get the version
         id: get_version
         run: |
           VERSION="${GITHUB_REF_NAME//v}"
           echo VERSION:${VERSION}
           echo ::set-output name=VERSION::${VERSION}         
-      # - uses: actions/checkout@v2    
-      # - name: Setup .NET Core
-      #   uses: actions/setup-dotnet@v1
-      #   with:
-      #     dotnet-version: 5.0.*
-      # - name: Install dependencies
-      #   run: dotnet restore -p:NuGetBuild=True -p:LangVersion=Latest
-      # - name: Build
-      #   run: dotnet build --configuration Release --no-restore -p:NuGetBuild=True -p:LangVersion=Latest
-      # - name: Pack
-      #   run: dotnet pack --output artifacts --configuration Release --no-restore --no-build  -p:NuGetBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }} -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true -p:LangVersion=Latest
-      # - name: Push with dotnet
-      #   run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source ${{ inputs.source }} --skip-duplicate
-      # - name: Archive artifacts
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     name: artifacts
-      #     path: artifacts          
+      - uses: actions/checkout@v2    
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.*
+      - name: Install dependencies
+        run: dotnet restore -p:NuGetBuild=True -p:LangVersion=Latest
+      - name: Build
+        run: dotnet build --configuration Release --no-restore -p:NuGetBuild=True -p:LangVersion=Latest
+      - name: Pack
+        run: dotnet pack --output artifacts --configuration Release --no-restore --no-build  -p:NuGetBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }} -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true -p:LangVersion=Latest
+      - name: Push with dotnet
+        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.apikey }} --source ${{ steps.sourceeval.outputs.value }} --skip-duplicate
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts          

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# Lombiq <add project name here>
+# Lombiq NuGet Publishing Github Actions
 
 
 
@@ -11,7 +11,69 @@ Do you want to quickly try out this project and see it in action? Check it out i
 
 ## Documentation
 
-Add detailed documentation here. If it's a lot of content then create documentation pages under the *Docs* folder and link pages here.
+Github actions shared between Lombiq projects.
+
+Refer [Github actions reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#overview)
+
+This includes two workflows that can be invoked through the `call-build-workflow` step.
+
+- build.yml
+- publish.yml
+
+
+To add to a project create a folder from the root of the repository that will call these actions `.github/workflows/build.yml` or `.github/workflows/publish.yml`
+
+Example `build.yml`
+
+```
+name: build
+
+on:
+  push:
+    branches: [dev]
+    paths-ignore:
+      - "Docs/**"
+      - "Readme.md"
+
+  pull_request:
+    branches: [dev]
+
+jobs:
+  call-build-workflow:
+    uses: Lombiq/NuGet-Publishing-GitHub-Actions/.github/workflows/build.yml@v1
+```
+
+This workflow is triggered on push to `dev` and pull requests to `dev` and invokes the `build.yml` workflow from this repository. It takes no parameters.
+
+Example `publish.yml`
+
+```
+name: publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  call-publish-workflow:
+    uses: Lombiq/NuGet-Publishing-GitHub-Actions/.github/workflows/publish.yml@v1
+    secrets:
+      apikey: ${{ secrets.LOMBIQ_NUGET_PUBLISH_API_KEY }}
+```
+
+The `publish.yml` workflow is triggered on a tag pushed to any branch with the prefix `v` and should contain a version number, i.e. `v1.0.1`, which will be extracted and used to version the NuGet packages produced.
+
+It takes one non optional secret parameter `apikey`, the organization API key for pushing to NuGet, and one optional parameter, `source`
+
+`source`
+```
+    uses: Lombiq/NuGet-Publishing-GitHub-Actions/.github/workflows/publish.yml@v1
+    with:
+      source: `custom-nuget-source-to-push-too`
+```
+
+When `source` is not provided, it assumes a default value of pushing to the [Lombiq nuget feed](https://www.nuget.org/profiles/Lombiq).
 
 
 ## Contributing and support

--- a/Readme.md
+++ b/Readme.md
@@ -4,28 +4,21 @@
 
 ## About
 
-Add a general overview of the project here. Don't forget to update the year in the Licence! Keep or remove the OSOCE note below as necessary.
-
-Do you want to quickly try out this project and see it in action? Check it out in our [Open-Source Orchard Core Extensions](https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions) full Orchard Core solution and also see our other useful Orchard Core-related open-source projects!
+Github Actions shared between Lombiq projects, used to publish packages to NuGet.
 
 
 ## Documentation
 
-Github actions shared between Lombiq projects.
+This includes two workflows that can be invoked through the `call-build-workflow` step:
 
-Refer [Github actions reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#overview)
+- _build.yml_: Builds the project with the .NET SDK.
+- _publish.yml_: Builds the project with the .NET SDK and publishes it as a NuGet package to the configured NuGet feed.
 
-This includes two workflows that can be invoked through the `call-build-workflow` step.
+To add to a project create a folder from the root of the repository that will call these actions, _.github/workflows/build.yml_ and/or _.github/workflows/publish.yml_.
 
-- build.yml
-- publish.yml
+Example _build.yml_:
 
-
-To add to a project create a folder from the root of the repository that will call these actions `.github/workflows/build.yml` or `.github/workflows/publish.yml`
-
-Example `build.yml`
-
-```
+```yaml
 name: build
 
 on:
@@ -43,11 +36,11 @@ jobs:
     uses: Lombiq/NuGet-Publishing-GitHub-Actions/.github/workflows/build.yml@v1
 ```
 
-This workflow is triggered on push to `dev` and pull requests to `dev` and invokes the `build.yml` workflow from this repository. It takes no parameters.
+This workflow is triggered on push to `dev` and pull requests to `dev` and invokes the _build.yml_ workflow from this repository. It takes no parameters.
 
-Example `publish.yml`
+Example _publish.yml_:
 
-```
+```yaml
 name: publish
 
 on:
@@ -62,18 +55,19 @@ jobs:
       apikey: ${{ secrets.LOMBIQ_NUGET_PUBLISH_API_KEY }}
 ```
 
-The `publish.yml` workflow is triggered on a tag pushed to any branch with the prefix `v` and should contain a version number, i.e. `v1.0.1`, which will be extracted and used to version the NuGet packages produced.
+The _publish.yml_ workflow is triggered on a tag pushed to any branch with the prefix `v` and should contain a version number, e.g. `v1.0.1`, which will be extracted and used to version the NuGet packages produced.
 
-It takes one non optional secret parameter `apikey`, the organization API key for pushing to NuGet, and one optional parameter, `source`
+It takes one non-optional secret parameter, `apikey`, the organization API key for pushing to NuGet, and one optional parameter, `source`:
 
-`source`
-```
+```yaml
     uses: Lombiq/NuGet-Publishing-GitHub-Actions/.github/workflows/publish.yml@v1
     with:
       source: `custom-nuget-source-to-push-too`
 ```
 
-When `source` is not provided, it assumes a default value of pushing to the [Lombiq nuget feed](https://www.nuget.org/profiles/Lombiq).
+When `source` is not provided, it assumes a default value of pushing to the [Lombiq NuGet feed](https://www.nuget.org/profiles/Lombiq).
+
+Refer to [Github Actions reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#overview) for more information.
 
 
 ## Contributing and support


### PR DESCRIPTION
Fixes https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/issues/23

Reusable workflows for build and publish.

This one needs to be merged first, and tagged `v1`

The tag is useful, because you can just move it to a different commit, if the changes are non-breaking, and the dependenat repos will use it.

Hence why there's only one tag, but many commits.

Will add some comments