### PR TITLE
OSOE-140: Substitute haya14busa/action-cond with a PS script in the publish workflow

### DIFF
--- a/.github/actions/build-dotnet/action.yml
+++ b/.github/actions/build-dotnet/action.yml
@@ -5,15 +5,15 @@ inputs:
   directory:
     required: false
     default: .
-    description: Path to the directory where a solution file can be found. Defaults to ".".
+    description: Path to the directory where a solution file can be found.
   verbosity:
     required: false
     default: quiet
-    description: Verbosity parameter for dotnet build. Defaults to "quiet".
+    description: Verbosity parameter for dotnet build.
   enable-code-analysis:
     required: false
     default: "true"
-    description: If set to "true", static code analysis is enabled during the build. Defaults to "true".
+    description: If set to "true", static code analysis is enabled during the build.
 
 runs:
   using: "composite"

--- a/.github/actions/setup-azurite/action.yml
+++ b/.github/actions/setup-azurite/action.yml
@@ -7,7 +7,7 @@ inputs:
   location:
     required: false
     default: .
-    description: Path to the directory where Azurite will be started and will store its logs. Defaults to ".".
+    description: Path to the directory where Azurite will be started and will store its logs.
 
 runs:
   using: "composite"

--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -5,7 +5,7 @@ inputs:
   dotnet-version:
     required: false
     default: 6.0.*
-    description: Version of the .NET SDK to set up. Defaults to 6.0.*.
+    description: Version of the .NET SDK to set up.
 
 runs:
   using: "composite"

--- a/.github/actions/test-dotnet/action.yml
+++ b/.github/actions/test-dotnet/action.yml
@@ -9,11 +9,11 @@ inputs:
     required: false
     default: .
     description: >
-      Path to the directory where a solution file can be found and thus the .NET build has run. Defaults to ".".
+      Path to the directory where a solution file can be found and thus the .NET build has run.
   test-verbosity:
     required: false
     default: quiet
-    description: Verbosity parameter for dotnet test. Defaults to "quiet".
+    description: Verbosity parameter for dotnet test.
 
 runs:
   using: "composite"

--- a/.github/actions/test-dotnet/action.yml
+++ b/.github/actions/test-dotnet/action.yml
@@ -8,8 +8,7 @@ inputs:
   build-directory:
     required: false
     default: .
-    description: >
-      Path to the directory where a solution file can be found and thus the .NET build has run.
+    description: Path to the directory where a solution file can be found and thus the .NET build has run.
   test-verbosity:
     required: false
     default: quiet

--- a/.github/workflows/build-and-test-orchard-core.yml
+++ b/.github/workflows/build-and-test-orchard-core.yml
@@ -11,33 +11,32 @@ on:
         default: "[\"ubuntu-latest\"]"
         description: >
             Stringified JSON array with the name of the type of machine(s) to run the workflow under, e.g.
-            "[\"ubuntu-latest\"]" or "[\"ubuntu-latest\", \"windows-latest\"]". Defaults to "[\"ubuntu-latest\"]".
+            "[\"ubuntu-latest\"]" or "[\"ubuntu-latest\", \"windows-latest\"]".
       dotnet-version:
         required: false
         type: string
         default: 6.0.*
-        description: >
-          Version of the .NET SDK to set up. Defaults to 6.0.*.
+        description: Version of the .NET SDK to set up.
       build-directory:
         required: false
         type: string
         default: .
-        description: Path to the directory where a solution file can be found. Defaults to ".".
+        description: Path to the directory where a solution file can be found.
       build-verbosity:
         required: false
         type: string
         default: quiet
-        description: Verbosity parameter for dotnet build. Defaults to "quiet".
+        description: Verbosity parameter for dotnet build.
       build-enable-code-analysis:
         required: false
         type: string
         default: "true"
-        description: Indicates whether to enable static code analysis during dotnet build. Defaults to "true".
+        description: Indicates whether to enable static code analysis during dotnet build.
       timeout-minutes:
         required: false
         type: number
         default: 360
-        description: Configuration for the timeout-minutes parameter of the workflow. Defaults to 360 (the GitHub default).
+        description: Configuration for the timeout-minutes parameter of the workflow. The 360 is GitHub's default.
 
 jobs:
   build-and-test:

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
         default: 6.0.*
-        description: Version of the .NET SDK to set up. Defaults to "6.0.*".
+        description: Version of the .NET SDK to set up. Defaults to "${{ inputs.dotnet-version.default }}".
       build-directory:
         required: false
         type: string

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -11,32 +11,32 @@ on:
         default: "[\"ubuntu-latest\"]"
         description: >
             Stringified JSON array with the name of the type of machine(s) to run the workflow under, e.g.
-            "[\"ubuntu-latest\"]" or "[\"ubuntu-latest\", \"windows-latest\"]". Defaults to "[\"ubuntu-latest\"]".
+            "[\"ubuntu-latest\"]" or "[\"ubuntu-latest\", \"windows-latest\"]".
       dotnet-version:
         required: false
         type: string
         default: 6.0.*
-        description: Version of the .NET SDK to set up. Defaults to "${{ inputs.dotnet-version.default }}".
+        description: Version of the .NET SDK to set up.
       build-directory:
         required: false
         type: string
         default: .
-        description: Path to the directory where a solution file can be found. Defaults to ".".
+        description: Path to the directory where a solution file can be found.
       build-verbosity:
         required: false
         type: string
         default: quiet
-        description: Verbosity parameter for dotnet build. Defaults to "quiet".
+        description: Verbosity parameter for dotnet build.
       build-enable-code-analysis:
         required: false
         type: string
         default: "true"
-        description: Indicates whether to enable static code analysis during dotnet build. Defaults to "true".
+        description: Indicates whether to enable static code analysis during dotnet build.
       timeout-minutes:
         required: false
         type: number
         default: 360
-        description: Configuration for the timeout-minutes parameter of the workflow. Defaults to 360 (the GitHub default).
+        description: Configuration for the timeout-minutes parameter of the workflow. The 360 is GitHub's default.
 
 jobs:
   # While the below steps seem suitable to DRY with build-and-test-orchard-core, since reusable workflows can't call

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -16,8 +16,7 @@ on:
         required: false
         type: string
         default: 6.0.*
-        description: >
-          Version of the .NET SDK to set up. Defaults to 6.0.*.
+        description: Version of the .NET SDK to set up. Defaults to "6.0.*".
       build-directory:
         required: false
         type: string

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,7 +183,21 @@ jobs:
         # * -p:ContinuousIntegrationBuild=true is needed for Deterministic Builds:
         #   https://github.com/clairernovotny/DeterministicBuilds.
         # * -p:DebugSymbols=true and -p:DebugType=portable are needed to generate PDB files.
-        run: dotnet build --configuration Release --no-restore -p:NuGetBuild=true -p:LangVersion=Latest -p:GenerateDocumentationFile=True -p:NoWarn=CS1573%3BCS1591%3BVSTHRD002%3BVSTHRD200 -p:EnableNETAnalyzers=false -p:ContinuousIntegrationBuild=true -p:DebugSymbols=true -p:DebugType=portable --verbosity ${{ inputs.verbosity }}
+        run: |
+          $Arguments = @(
+              "--configuration:Release",
+              "--no-restore",
+              "--verbosity:${{ inputs.verbosity }}",
+              "-p:NuGetBuild=true",
+              "-p:LangVersion=Latest",
+              "-p:GenerateDocumentationFile=True",
+              "-p:NoWarn=CS1573%3BCS1591%3BVSTHRD002%3BVSTHRD200",
+              "-p:EnableNETAnalyzers=false",
+              "-p:ContinuousIntegrationBuild=true",
+              "-p:DebugSymbols=true",
+              "-p:DebugType=portable"
+          )
+          dotnet build @Arguments
 
       - name: Pack
         # Notes on the configuration apart from what's also for dotnet build:
@@ -193,7 +207,25 @@ jobs:
         #   a non-packagable project.
         # * -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg are needed to generate symbol packages:
         #   https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg.
-        run: dotnet pack --output artifacts --configuration Release --no-restore --no-build -p:NuGetBuild=true "-p:Version=$Env:PUBLISH_VERSION" -p:GenerateDocumentationFile=True -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true -warnaserror -p:WarnOnPackingNonPackableProject=True -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:NoDefaultExcludes=true --verbosity ${{ inputs.verbosity }}
+        run: |
+          $Arguments = @(
+              "--configuration:Release",
+              "--warnaserror",
+              "--no-restore",
+              "--no-build",
+              "--output:artifacts",
+              "--verbosity:${{ inputs.verbosity }}",
+              "-p:NuGetBuild=true",
+              "-p:Version=$Env:PUBLISH_VERSION",
+              "-p:GenerateDocumentationFile=True",
+              "-p:NoWarn=NU5104",
+              "-p:TreatWarningsAsErrors=true",
+              "-p:WarnOnPackingNonPackableProject=True",
+              "-p:IncludeSymbols=true",
+              "-p:SymbolPackageFormat=snupkg",
+              "-p:NoDefaultExcludes=true"
+          )
+          dotnet pack @Arguments   
 
       - name: Push with dotnet
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.API_KEY }} --source $Env:SOURCE_URL --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,11 +34,6 @@ jobs:
           ${{ inputs.source }}
           '@.Trim()
 
-          if ([string]::IsNullOrEmpty($source)) 
-          {
-              $source = 'https://api.nuget.org/v3/index.json';
-          }
-
           Write-Output "NuGet Source: $source"
           "SOURCE_URL=$source" >> $Env:GITHUB_ENV
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,16 +20,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      # v1.1.0
-      - uses: haya14busa/action-cond@c69871f4d4693e93126e770d7c3588cb1d473462
-        id: source-value
-        with:
-          cond: ${{ inputs.source == '' }}
-          if_true: "https://api.nuget.org/v3/index.json"
-          if_false: "${{ inputs.source }}"
-
       - name: Print source
-        run: echo NuGet Source:${{ steps.source-value.outputs.value }}
+        shell: pwsh
+        run: |
+          $Source = @'
+          ${{ inputs.source }}
+          '@.Trim()
+
+          if ([string]::IsNullOrEmpty($Source)) 
+          {
+              $Source = 'https://api.nuget.org/v3/index.json';
+          }
+
+          Write-Output "NuGet Source: $Source"
+          "SOURCE_URL=$Source" >> $Env:GITHUB_ENV
 
       - name: Get the version
         id: get-version
@@ -183,7 +187,7 @@ jobs:
         run: dotnet pack --output artifacts --configuration Release --no-restore --no-build -p:NuGetBuild=true -p:Version=${{ steps.get-version.outputs.VERSION }} -p:GenerateDocumentationFile=True -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true -warnaserror -p:WarnOnPackingNonPackableProject=True -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:NoDefaultExcludes=true --verbosity ${{ inputs.verbosity }}
 
       - name: Push with dotnet
-        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.API_KEY }} --source ${{ steps.source-value.outputs.value }} --skip-duplicate
+        run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.API_KEY }} --source $Env:SOURCE_URL --skip-duplicate
 
       - name: Publish Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Print Source
-        shell: pwsh
         run: |
           $source = @'
           ${{ inputs.source }}
@@ -126,7 +125,6 @@ jobs:
           program Microsoft.SourceLink.GitHub
 
       - name: Update package manifest version
-        shell: pwsh
         run: |
             function Program {
                 param(

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,23 +32,23 @@ jobs:
       - name: Print Source
         shell: pwsh
         run: |
-          $Source = @'
+          $source = @'
           ${{ inputs.source }}
           '@.Trim()
 
-          if ([string]::IsNullOrEmpty($Source)) 
+          if ([string]::IsNullOrEmpty($source)) 
           {
-              $Source = 'https://api.nuget.org/v3/index.json';
+              $source = 'https://api.nuget.org/v3/index.json';
           }
 
-          Write-Output "NuGet Source: $Source"
-          "SOURCE_URL=$Source" >> $Env:GITHUB_ENV
+          Write-Output "NuGet Source: $source"
+          "SOURCE_URL=$source" >> $Env:GITHUB_ENV
 
       - name: Get the Version
         run: |
-          $Version = $Env:GITHUB_REF_NAME.Trim().Substring(1)
-          Write-Output "VERSION: $Version"
-          "PUBLISH_VERSION=$Version" >> $Env:GITHUB_ENV
+          $version = $Env:GITHUB_REF_NAME.Trim().Substring(1)
+          Write-Output "Target Version: $version"
+          "PUBLISH_VERSION=$version" >> $Env:GITHUB_ENV
 
       - uses: actions/checkout@v3
 
@@ -184,7 +184,7 @@ jobs:
         #   https://github.com/clairernovotny/DeterministicBuilds.
         # * -p:DebugSymbols=true and -p:DebugType=portable are needed to generate PDB files.
         run: |
-          $Arguments = @(
+          $arguments = @(
               "--configuration:Release",
               "--no-restore",
               "--verbosity:${{ inputs.verbosity }}",
@@ -197,7 +197,7 @@ jobs:
               "-p:DebugSymbols=true",
               "-p:DebugType=portable"
           )
-          dotnet build @Arguments
+          dotnet build @arguments
 
       - name: Pack
         # Notes on the configuration apart from what's also for dotnet build:
@@ -208,7 +208,7 @@ jobs:
         # * -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg are needed to generate symbol packages:
         #   https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg.
         run: |
-          $Arguments = @(
+          $arguments = @(
               "--configuration:Release",
               "--warnaserror",
               "--no-restore",
@@ -225,7 +225,7 @@ jobs:
               "-p:SymbolPackageFormat=snupkg",
               "-p:NoDefaultExcludes=true"
           )
-          dotnet pack @Arguments   
+          dotnet pack @arguments   
 
       - name: Push with dotnet
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.API_KEY }} --source $Env:SOURCE_URL --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,7 @@ on:
         required: false
         type: string
         default: https://api.nuget.org/v3/index.json
-        description: >
-          The NuGet server URL used by the `dotnet nuget push` command's `--source` argument. 
-          Defaults to "https://api.nuget.org/v3/index.json".
+        description: The NuGet server URL used by the `dotnet nuget push` command's `--source` argument. 
       verbosity:
         required: false
         type: string

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,15 @@ on:
       API_KEY:
         required: true
 
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Print source
+      - name: Print Source
         shell: pwsh
         run: |
           $Source = @'
@@ -40,14 +44,13 @@ jobs:
           Write-Output "NuGet Source: $Source"
           "SOURCE_URL=$Source" >> $Env:GITHUB_ENV
 
-      - name: Get the version
-        id: get-version
+      - name: Get the Version
         run: |
-          VERSION="${GITHUB_REF_NAME//v}"
-          echo VERSION:${VERSION}
-          echo ::set-output name=VERSION::${VERSION}
+          $Version = $Env:GITHUB_REF_NAME.Trim().Substring(1)
+          Write-Output "VERSION: $Version"
+          "PUBLISH_VERSION=$Version" >> $Env:GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
@@ -55,6 +58,7 @@ jobs:
           dotnet-version: 6.0.*
 
       - name: Add Source Link package
+        shell: bash
         run: |
           # Never edit this on its own. First update and test the scripts/add-package.sh file, then
           # copy the `program` function here and call it with `program Microsoft.SourceLink.GitHub`.
@@ -163,7 +167,7 @@ jobs:
                 }
             }
 
-            Program './' '${{ steps.get-version.outputs.VERSION }}'
+            Program './' $Env:PUBLISH_VERSION
 
       - name: Install dependencies
         run: dotnet restore -p:NuGetBuild=true --verbosity ${{ inputs.verbosity }}
@@ -189,7 +193,7 @@ jobs:
         #   a non-packagable project.
         # * -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg are needed to generate symbol packages:
         #   https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg.
-        run: dotnet pack --output artifacts --configuration Release --no-restore --no-build -p:NuGetBuild=true -p:Version=${{ steps.get-version.outputs.VERSION }} -p:GenerateDocumentationFile=True -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true -warnaserror -p:WarnOnPackingNonPackableProject=True -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:NoDefaultExcludes=true --verbosity ${{ inputs.verbosity }}
+        run: dotnet pack --output artifacts --configuration Release --no-restore --no-build -p:NuGetBuild=true "-p:Version=$Env:PUBLISH_VERSION" -p:GenerateDocumentationFile=True -p:NoWarn=NU5104 -p:TreatWarningsAsErrors=true -warnaserror -p:WarnOnPackingNonPackableProject=True -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:NoDefaultExcludes=true --verbosity ${{ inputs.verbosity }}
 
       - name: Push with dotnet
         run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.API_KEY }} --source $Env:SOURCE_URL --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get the Version
         run: |
-          $version = $Env:GITHUB_REF_NAME.Trim().Substring(1)
+          $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
           Write-Output "Target Version: $version"
           "PUBLISH_VERSION=$version" >> $Env:GITHUB_ENV
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,15 @@ on:
       source:
         required: false
         type: string
+        default: https://api.nuget.org/v3/index.json
+        description: >
+          The NuGet server URL used by the `dotnet nuget push` command's `--source` argument. 
+          Defaults to "https://api.nuget.org/v3/index.json".
       verbosity:
         required: false
         type: string
         default: minimal
+        description: The logging verbosity type used by the `dotnet` command.
     secrets:
       # We can't access org secrets here so they need to be passed in, see:
       # https://github.community/t/resuable-called-workflow-environment-variables-secrets-and-trigger-event-access/207723/2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ wwwroot/
 node_modules/
 *.user
 .pnpm-debug.log
+/.editorconfig


### PR DESCRIPTION
OSOE-140

This has been tested on a temporary branch for Lombiq.AuditTrailExtensions. You can see the successful run [here](https://github.com/Lombiq/Audit-Trail-Extensions/runs/6989302849?check_suite_focus=true) and the successful publish [here](https://www.nuget.org/packages/Lombiq.AuditTrailExtensions#versions-body-tab). I used the `v0.0.0.1-osoe-140.1` tag to avoid publishing an empty pre-release above the current latest version.