### PR TITLE
OCC-29: Use steps.setup.outputs.publish-version

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -173,7 +173,7 @@ runs:
       uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37
       # This is to prevent creating releases when pushing tags for issue-specific pre-releases like
       # v4.3.1-alpha.osoe-86.
-      if: "!contains(github.ref, '-')"
+      if: "!contains(steps.setup.outputs.publish-version, '-')"
       with:
         allowUpdates: true
         generateReleaseNotes: true


### PR DESCRIPTION
instead of `github.ref` because `$Env:GITHUB_REF_NAME` is not used in every scenario any more.