### PR TITLE
VSIX-54: Updating ncipollo/release-action to latest to get rid of set-output deprecation warnings

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -173,8 +173,8 @@ runs:
 
     # This is not in its own action because it's all very specific to this NuGet publishing.
     - name: Create Release
-      # v1.10.0
-      uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37
+      # v1.11.2
+      uses: ncipollo/release-action@18eadf9c9b0f226f47f164f5373c6a44f0aae169
       # This is to prevent creating releases when pushing tags for issue-specific pre-releases like
       # v4.3.1-alpha.osoe-86.
       if: "!contains(steps.setup.outputs.publish-version, '-')"


### PR DESCRIPTION
VSIX-54