### PR TITLE
OSOE-528: PSReviewUnusedParameter in-place suppression instead of disabling the rule in Lombiq.Analyzers.PowerShell

### DIFF
--- a/.github/actions/check-pull-request-labels/Test-PullRequestLabels.ps1
+++ b/.github/actions/check-pull-request-labels/Test-PullRequestLabels.ps1
@@ -1,6 +1,14 @@
 # We need to fetch the PR details from the API as opposed to just using the context because a label added after the
 # start of the run wouldn't be present in it.
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter',
+    'Label1',
+    Justification = 'False positive due to https://github.com/PowerShell/PSScriptAnalyzer/issues/1472.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter',
+    'Label2',
+    Justification = 'False positive due to https://github.com/PowerShell/PSScriptAnalyzer/issues/1472.')]
 param($Repository, $PullRequestNumber, $Label1, $Label2)
 
 # See https://cli.github.com/manual/gh_pr_view


### PR DESCRIPTION
[OSOE-528](https://lombiq.atlassian.net/browse/OSOE-528)

[OSOE-528]: https://lombiq.atlassian.net/browse/OSOE-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ