### PR TITLE
CARE-327: Use 64-bit MSBuild version in msbuild build

### DIFF
--- a/.github/actions/msbuild/action.yml
+++ b/.github/actions/msbuild/action.yml
@@ -53,6 +53,7 @@ runs:
       uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506
       with:
         vs-version: "[17.3,]"
+        msbuild-architecture: x64
 
     - name: Build and Static Code Analysis
       shell: pwsh

--- a/.github/workflows/msbuild-and-test.yml
+++ b/.github/workflows/msbuild-and-test.yml
@@ -88,7 +88,7 @@ jobs:
         uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
 
       - name: Build and Static Code Analysis
-        uses: Lombiq/GitHub-Actions/.github/actions/msbuild@issue/CARE-327
+        uses: Lombiq/GitHub-Actions/.github/actions/msbuild@dev
         with:
           directory: ${{ inputs.build-directory }}
           solution-or-project-path: ${{ inputs.solution-or-project-path }}

--- a/.github/workflows/msbuild-and-test.yml
+++ b/.github/workflows/msbuild-and-test.yml
@@ -88,7 +88,7 @@ jobs:
         uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
 
       - name: Build and Static Code Analysis
-        uses: Lombiq/GitHub-Actions/.github/actions/msbuild@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/msbuild@issue/CARE-327
         with:
           directory: ${{ inputs.build-directory }}
           solution-or-project-path: ${{ inputs.solution-or-project-path }}


### PR DESCRIPTION
[CARE-327](https://lombiq.atlassian.net/browse/CARE-327)

[CARE-327]: https://lombiq.atlassian.net/browse/CARE-327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ