### PR TITLE
OSOE-536: In NuGet publish workflow, restrict valid versions to vM.N.O or v.M.N.O-alpha.X.[issue-code]

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -62,7 +62,7 @@ runs:
 
         if ($version -eq 'USE_GITHUB_REF_NAME') {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
-            if (!($version -match '^v?(\d+\.\d+\.\d+)(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
+            if (!($version -match '^v?\d+\.\d+\.\d+(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
                 Write-Output "Invalid version number! The correct format is vM.N.O or v.M.N.O-alpha.X.[issue-code]."
                 exit 1
             }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -61,7 +61,7 @@ runs:
         '@.Trim()
 
         if ($version -eq 'USE_GITHUB_REF_NAME') {
-            if (($version -match '^v?\d+(\.\d+){0,3}-(\w+\.)+\d+\.\w+-\d+$') -or ($version -match '^v?\d+(\.\d+){0,3}$')) {
+            if ($version -match '^v?(\d+\.\d+\.\d+)(-alpha\.\d+\.[a-z]{2,}-\d+)?$') {
                 $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
             } else {
                 Write-Output "Invalid version number! The correct format is vM.N.O or v.M.N.O-alpha.X.[issue-code]."
@@ -70,7 +70,7 @@ runs:
         }
         if ($version -eq 'USE_GITHUB_RUN_NUMBER') {
           $tags = git tag |
-            ? { ($_ -match '^v?\d+(\.\d+){0,3}$') -or ($_ -match '^v?\d+(\.\d+){0,3}-(\w+\.)+\d+\.\w+-\d+$') } |
+            ? { ($_ -match '^v?(\d+\.\d+\.\d+)(-alpha\.\d+\.[a-z]{2,}-\d+)?$') } |
             % { [version]($_.TrimStart("v")) } |
             Sort-Object -Descending
           $current = if ($tags.Count -gt 0) { $tags[0] } else { [version]"0.0.0" }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -69,7 +69,7 @@ runs:
         }
         if ($version -eq 'USE_GITHUB_RUN_NUMBER') {
           $tags = git tag |
-            ? { $_ -match '^v?\d+(\.\d+){0,3}$' } |
+            ? { $_ -match '^v?\d+\.\d+\.\d+$' } |
             % { [version]($_.TrimStart("v")) } |
             Sort-Object -Descending
           $current = if ($tags.Count -gt 0) { $tags[0] } else { [version]"0.0.0" }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -63,7 +63,7 @@ runs:
         if ($version -eq 'USE_GITHUB_REF_NAME') {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
             if (!($version -match '^\d+\.\d+\.\d+(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
-                Write-Output "::error::$version is an invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.[issue-code]."
+                Write-Output "::error::`"v$version`" is invalid. The correct format is `"vM.N.O`" or `"vM.N.O-alpha.X.<issue-code>`"."
                 exit 1
             }
         }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -60,7 +60,14 @@ runs:
         ${{ inputs.publish-version }}
         '@.Trim()
 
-        if ($version -eq 'USE_GITHUB_REF_NAME') { $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v") }
+        if ($version -eq 'USE_GITHUB_REF_NAME') {
+            if (($version -match '^v?\d+(\.\d+){0,3}-(\w+\.)+\d+\.\w+-\d+$') -or ($version -match '^v?\d+(\.\d+){0,3}$')) {
+                $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
+            } else {
+                Write-Output "version number is not in a correct format."
+                exit 1
+            }
+        }
         if ($version -eq 'USE_GITHUB_RUN_NUMBER') {
           $tags = git tag |
             ? { $_ -match '^v?\d+(\.\d+){0,3}$' } |

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -63,7 +63,7 @@ runs:
         if ($version -eq 'USE_GITHUB_REF_NAME') {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
             if (!($version -match '^\d+\.\d+\.\d+(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
-                Write-Output "::error::$version is an invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.{issue-code}."
+                Write-Output "::error::invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.{issue-code}."
                 exit 1
             }
         }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -61,9 +61,8 @@ runs:
         '@.Trim()
 
         if ($version -eq 'USE_GITHUB_REF_NAME') {
-            if ($version -match '^v?(\d+\.\d+\.\d+)(-alpha\.\d+\.[a-z]{2,}-\d+)?$') {
-                $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
-            } else {
+            $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
+            if (!($version -match '^v?(\d+\.\d+\.\d+)(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
                 Write-Output "Invalid version number! The correct format is vM.N.O or v.M.N.O-alpha.X.[issue-code]."
                 exit 1
             }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -63,7 +63,7 @@ runs:
         if ($version -eq 'USE_GITHUB_REF_NAME') {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
             if (!($version -match '^\d+\.\d+\.\d+(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
-                Write-Output "Invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.[issue-code]."
+                Write-Output "::error::$version is an invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.{issue-code}."
                 exit 1
             }
         }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -64,13 +64,13 @@ runs:
             if (($version -match '^v?\d+(\.\d+){0,3}-(\w+\.)+\d+\.\w+-\d+$') -or ($version -match '^v?\d+(\.\d+){0,3}$')) {
                 $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
             } else {
-                Write-Output "version number is not in a correct format."
+                Write-Output "Invalid version number! The correct format is vM.N.O or v.M.N.O-alpha.X.[issue-code]."
                 exit 1
             }
         }
         if ($version -eq 'USE_GITHUB_RUN_NUMBER') {
           $tags = git tag |
-            ? { $_ -match '^v?\d+(\.\d+){0,3}$' } |
+            ? { ($_ -match '^v?\d+(\.\d+){0,3}$') -or ($_ -match '^v?\d+(\.\d+){0,3}-(\w+\.)+\d+\.\w+-\d+$') } |
             % { [version]($_.TrimStart("v")) } |
             Sort-Object -Descending
           $current = if ($tags.Count -gt 0) { $tags[0] } else { [version]"0.0.0" }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -63,7 +63,7 @@ runs:
         if ($version -eq 'USE_GITHUB_REF_NAME') {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
             if (!($version -match '^\d+\.\d+\.\d+(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
-                Write-Output "::error::invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.[issue-code]."
+                Write-Output "::error::$version is an invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.[issue-code]."
                 exit 1
             }
         }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -63,7 +63,7 @@ runs:
         if ($version -eq 'USE_GITHUB_REF_NAME') {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
             if (!($version -match '^\d+\.\d+\.\d+(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
-                Write-Output "::error::invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.{issue-code}."
+                Write-Output "::error::invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.[issue-code]."
                 exit 1
             }
         }

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -62,14 +62,14 @@ runs:
 
         if ($version -eq 'USE_GITHUB_REF_NAME') {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
-            if (!($version -match '^v?\d+\.\d+\.\d+(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
-                Write-Output "Invalid version number! The correct format is vM.N.O or v.M.N.O-alpha.X.[issue-code]."
+            if (!($version -match '^\d+\.\d+\.\d+(-alpha\.\d+\.[a-z]{2,}-\d+)?$')) {
+                Write-Output "Invalid version number! The correct format is vM.N.O or vM.N.O-alpha.X.[issue-code]."
                 exit 1
             }
         }
         if ($version -eq 'USE_GITHUB_RUN_NUMBER') {
           $tags = git tag |
-            ? { ($_ -match '^v?(\d+\.\d+\.\d+)(-alpha\.\d+\.[a-z]{2,}-\d+)?$') } |
+            ? { $_ -match '^v?\d+(\.\d+){0,3}$' } |
             % { [version]($_.TrimStart("v")) } |
             Sort-Object -Descending
           $current = if ($tags.Count -gt 0) { $tags[0] } else { [version]"0.0.0" }

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -55,8 +55,8 @@ on:
         type: string
         default: "USE_GITHUB_REF_NAME"
         description: >
-          The desired NuGet package version used for publishing. If not specified, the GITHUB_REF_NAME environment
-          variable is used which is suitable if the version is derived from a git tag.
+          The desired NuGet package version used for publishing. The correct input format is vM.N.O or vM.N.O-alpha.X.[issue-code].
+          If not specified, the GITHUB_REF_NAME environment variable is used which is suitable if the version is derived from a git tag.
       nuget-artifact-retention-days:
         required: false
         type: string
@@ -73,12 +73,12 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-536
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-536
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
@@ -96,6 +96,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-536
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -55,7 +55,7 @@ on:
         type: string
         default: "USE_GITHUB_REF_NAME"
         description: >
-          The desired NuGet package version used for publishing. The correct input format is vM.N.O or vM.N.O-alpha.X.[issue-code].
+          The desired NuGet package version used for publishing. The correct input format is vM.N.O or vM.N.O-alpha.X.{issue-code}.
           If not specified, the GITHUB_REF_NAME environment variable is used which is suitable if the version is derived from a git tag.
       nuget-artifact-retention-days:
         required: false

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -55,7 +55,7 @@ on:
         type: string
         default: "USE_GITHUB_REF_NAME"
         description: >
-          The desired NuGet package version used for publishing. The correct input format is vM.N.O or vM.N.O-alpha.X.{issue-code}.
+          The desired NuGet package version used for publishing. The correct input format is vM.N.O or vM.N.O-alpha.X.[issue-code].
           If not specified, the GITHUB_REF_NAME environment variable is used which is suitable if the version is derived from a git tag.
       nuget-artifact-retention-days:
         required: false

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -55,8 +55,9 @@ on:
         type: string
         default: "USE_GITHUB_REF_NAME"
         description: >
-          The desired NuGet package version used for publishing. The correct input format is vM.N.O or vM.N.O-alpha.X.[issue-code].
-          If not specified, the GITHUB_REF_NAME environment variable is used which is suitable if the version is derived from a git tag.
+          The desired NuGet package version used for publishing. The correct format is "vM.N.O" or
+          "vM.N.O-alpha.X.<issue-code>". If not specified, the GITHUB_REF_NAME environment variable is used
+          which is suitable if the version is derived from a git tag.
       nuget-artifact-retention-days:
         required: false
         type: string

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -73,17 +73,17 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-536
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-536
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-536
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}
@@ -96,6 +96,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-536
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[OSOE-536](https://lombiq.atlassian.net/browse/OSOE-536)
Fixes #187 

[OSOE-536]: https://lombiq.atlassian.net/browse/OSOE-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ