### PR TITLE
CARE-360: Revert "Add dotnet-version to msbuild-and-test workflow"

### DIFF
--- a/.github/workflows/msbuild-and-test.yml
+++ b/.github/workflows/msbuild-and-test.yml
@@ -21,11 +21,6 @@ on:
         default: "windows-2022"
         description: >
           The machine type to run the workflow under, e.g. "windows-2022". Needs to be Windows.
-      dotnet-version:
-        required: false
-        type: string
-        default: 7.0.x
-        description: Version of the .NET SDK to set up.
       build-directory:
         required: false
         type: string
@@ -91,8 +86,6 @@ jobs:
       # This is necessary for building Gulp Extensions and test-dotnet.
       - name: Set up .NET
         uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
-        with:
-          dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Build and Static Code Analysis
         uses: Lombiq/GitHub-Actions/.github/actions/msbuild@dev


### PR DESCRIPTION
[CARE-360](https://lombiq.atlassian.net/browse/CARE-360)
This reverts commit 6049aeb85cc656650f818f79577e066eb6dfb23f.

[CARE-360]: https://lombiq.atlassian.net/browse/CARE-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ