### PR TITLE
Test OSOE-517 on new pull request

### DIFF
--- a/.github/actions/verify-gha-refs/Check-Called-GHA-Refs.ps1
+++ b/.github/actions/verify-gha-refs/Check-Called-GHA-Refs.ps1
@@ -21,7 +21,7 @@ $mismatchRefs = Get-ChildItem -Path $PathIncludeList -Include $FileIncludeList -
 
 if ($mismatchRefs.Count -gt 0)
 {
-    "These called workflows and actions do not match expected ref '$ExpectedRef'." >> $env:GITHUB_STEP_SUMMARY
+    "These called GitHub Actions and Workflows do not match expected ref '$ExpectedRef'." >> $env:GITHUB_STEP_SUMMARY
 
     foreach ($mismatch in $mismatchRefs)
     {
@@ -31,10 +31,12 @@ if ($mismatchRefs.Count -gt 0)
 
         # The below statement won't work becuase actions/toolkit will not link to files that are not part of the commit.
         # See: https://github.com/actions/toolkit/issues/470
-        # Write-Output "::error file=$filename,line=$linenumber,title=$title::GHA Ref does not match '${{ inputs.expected-ref }}'"
+        # Write-Output "::error file=$filename,line=$linenumber,title=$title::GHA Ref does not match '$ExpectedRef'"
 
         # As a workaround, link directly to file.
         "- <a href='https://github.com/$GitHubRepository/blob/$GitHubRefName/$filename#L$linenumber'>$filename#L$linenumber</a>" >> $env:GITHUB_STEP_SUMMARY
+        # And write better log message.
+        Write-Output "::error::$filename#L$linenumber - called GitHub Action does not match expected Ref '$ExpectedRef'."
 
         # Beware the backtick character is the powershell escape character.
         "``````yaml" >> $env:GITHUB_STEP_SUMMARY
@@ -42,5 +44,6 @@ if ($mismatchRefs.Count -gt 0)
         "``````" >> $env:GITHUB_STEP_SUMMARY
     }
 
+    Write-Output "::error::Check Job Summary for more details on which GitHub Actions Refs do not match '$ExpectedRef'."
     exit 1
 }

--- a/.github/workflows/validate-this-gha-refs.yml
+++ b/.github/workflows/validate-this-gha-refs.yml
@@ -83,18 +83,18 @@ jobs:
 
       - name: Verify GitHub Actions Items Match Expected Ref (Pull)
         if: github.event_name == 'pull_request' && steps.add-prefix.outputs.prefixed-files != '@()'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@test/OSOE-517
         with:
           called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
           expected-ref: ${{ steps.determine-ref.outputs.expected-ref }}
 
       - name: Verify GitHub Actions Items Match Expected Ref (Approved PR)
         if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && steps.add-prefix.outputs.prefixed-files != '@()'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@test/OSOE-517
         with:
           called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
           expected-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Verify GitHub Actions Items Match Expected Ref (Push)
         if: github.event_name == 'push'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@test/OSOE-517

--- a/.github/workflows/validate-this-gha-refs.yml
+++ b/.github/workflows/validate-this-gha-refs.yml
@@ -83,18 +83,18 @@ jobs:
 
       - name: Verify GitHub Actions Items Match Expected Ref (Pull)
         if: github.event_name == 'pull_request' && steps.add-prefix.outputs.prefixed-files != '@()'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@test/OSOE-517
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
         with:
           called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
           expected-ref: ${{ steps.determine-ref.outputs.expected-ref }}
 
       - name: Verify GitHub Actions Items Match Expected Ref (Approved PR)
         if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && steps.add-prefix.outputs.prefixed-files != '@()'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@test/OSOE-517
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
         with:
           called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
           expected-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Verify GitHub Actions Items Match Expected Ref (Push)
         if: github.event_name == 'push'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@test/OSOE-517
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev

--- a/.github/workflows/validate-this-gha-refs.yml
+++ b/.github/workflows/validate-this-gha-refs.yml
@@ -1,4 +1,4 @@
-name: Validate GHA Refs
+name: Validate GitHub Actions Refs
 on:
   push:
     branches:
@@ -40,7 +40,7 @@ jobs:
           right-commit: ${{ github.sha }}
           diff-filter: ${{ steps.git-diff-filter.outputs.git-diff-filter }}
 
-      - name: Get GHA Item Changes from File Changes
+      - name: Get GitHub Actions Item Changes from File Changes
         id: changed-items
         if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
         uses: Lombiq/GitHub-Actions/.github/actions/get-changed-gha-items@dev
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine Expected Ref for GHA Files
+      - name: Determine Expected Ref for GitHub Actions Files
         id: determine-ref
         if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
         shell: pwsh
@@ -81,20 +81,20 @@ jobs:
           $output = "expected-ref=$expectedRef"
           $output >> $env:GITHUB_OUTPUT
 
-      - name: Verify GHA Items Match Expected Ref (Pull)
+      - name: Verify GitHub Actions Items Match Expected Ref (Pull)
         if: github.event_name == 'pull_request' && steps.add-prefix.outputs.prefixed-files != '@()'
         uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
         with:
           called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
           expected-ref: ${{ steps.determine-ref.outputs.expected-ref }}
 
-      - name: Verify GHA Items Match Expected Ref (Approved PR)
+      - name: Verify GitHub Actions Items Match Expected Ref (Approved PR)
         if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && steps.add-prefix.outputs.prefixed-files != '@()'
         uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
         with:
           called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
           expected-ref: ${{ github.event.pull_request.base.ref }}
 
-      - name: Verify GHA Items Match Expected Ref (Push)
+      - name: Verify GitHub Actions Items Match Expected Ref (Push)
         if: github.event_name == 'push'
         uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev


### PR DESCRIPTION
Opening a new PR to test the full lifecycle of the [validate-this-gha-refs](https://github.com/Lombiq/GitHub-Actions/blob/dev/.github/workflows/validate-this-gha-refs.yml) workflow.

1. This Initial commit is expected to fail the `Validate GHA Refs` check because refs are not targeting this PR branch.
2. Subsequent commit should pass checks because refs of changed files match PR branch.
3. Reviewer should then approve PR.
4. Post PR approval, will trigger new check which is expected to fail ref checks because they will not match the PR's target `dev` branch.
5. A subsequent commit should pass checks because they'll match the expected `@dev` branch.