### PR TITLE
INFRA-149: Removing redundant call to install the SqlServer PowerShell module

### DIFF
--- a/.github/workflows/reset-azure-environment.yml
+++ b/.github/workflows/reset-azure-environment.yml
@@ -174,7 +174,6 @@ jobs:
 
       - name: Add Destination Contained User to Destination Database
         run: |
-          Install-Module sqlserver -AllowClobber -Force
           Add-AzureWebAppSqlDatabaseContainedUser `
             -ResourceGroupName ${{ inputs.resource-group-name }} `
             -WebAppName ${{ inputs.app-name }} `

--- a/.github/workflows/reset-azure-environment.yml
+++ b/.github/workflows/reset-azure-environment.yml
@@ -140,7 +140,7 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_APP_SERVICE_RESET_AZURE_SUBSCRIPTION_ID }}
 
       - name: Initialize PowerShell modules
-        uses: Lombiq/Infrastructure-Scripts/.github/actions/initialize@dev
+        uses: Lombiq/Infrastructure-Scripts/.github/actions/initialize@issue/INFRA-149
 
       - name: Stop Web App Slot
         run: |

--- a/.github/workflows/reset-azure-environment.yml
+++ b/.github/workflows/reset-azure-environment.yml
@@ -140,7 +140,7 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_APP_SERVICE_RESET_AZURE_SUBSCRIPTION_ID }}
 
       - name: Initialize PowerShell modules
-        uses: Lombiq/Infrastructure-Scripts/.github/actions/initialize@issue/INFRA-149
+        uses: Lombiq/Infrastructure-Scripts/.github/actions/initialize@dev
 
       - name: Stop Web App Slot
         run: |


### PR DESCRIPTION
[INFRA-149](https://lombiq.atlassian.net/browse/INFRA-149)
Because the initialize action called from Infrastructure Scripts already installs it.

[INFRA-149]: https://lombiq.atlassian.net/browse/INFRA-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ