### PR TITLE
OSOE-517: Add merge queue support for verifying GitHub Action expected refs

### DIFF
--- a/.github/actions/check-merge-queue-adds/Test-PullRequestMergeQueueAdds.ps1
+++ b/.github/actions/check-merge-queue-adds/Test-PullRequestMergeQueueAdds.ps1
@@ -3,7 +3,7 @@
 
 param($Repository, $PullRequestNumber)
 
-$repoTokens = $Repository.Split("/")
+$repoTokens = $Repository.Split('/')
 
 $repositoryOwner = $repoTokens[0]
 $repositoryName = $repoTokens[1]
@@ -14,7 +14,7 @@ Write-Output "name=$repositoryName"
 $query = "query(`$owner: String!, `$name: String!) {  repository(owner: `$owner name: `$name) {    pullRequest(number:$PullRequestNumber) {      timelineItems(itemTypes:ADDED_TO_MERGE_QUEUE_EVENT) {        totalCount      }    } } }"
 Write-Output "query=$query"
 
-$content = gh api graphql -F owner=$repositoryOwner -F name=$repositoryName -f query=$query | ConvertFrom-Json -ashashtable
+$content = gh api graphql -F owner=$repositoryOwner -F name=$repositoryName -f query=$query | ConvertFrom-Json -AsHashtable
 Write-Output "content=$content"
 
 $addedToMergeQueue = $content.data.repository.pullRequest.timelineItems.totalCount -gt 0

--- a/.github/actions/check-merge-queue-adds/Test-PullRequestMergeQueueAdds.ps1
+++ b/.github/actions/check-merge-queue-adds/Test-PullRequestMergeQueueAdds.ps1
@@ -1,0 +1,23 @@
+# We need to fetch the PR timeline details from the API because the context does not contain
+# this granular information.
+
+param($Repository, $PullRequestNumber)
+
+$repoTokens = $Repository.Split("/")
+
+$repositoryOwner = $repoTokens[0]
+$repositoryName = $repoTokens[1]
+
+Write-Output "owner=$repositoryOwner"
+Write-Output "name=$repositoryName"
+
+$query = "query(`$owner: String!, `$name: String!) {  repository(owner: `$owner name: `$name) {    pullRequest(number:$PullRequestNumber) {      timelineItems(itemTypes:ADDED_TO_MERGE_QUEUE_EVENT) {        totalCount      }    } } }"
+Write-Output "query=$query"
+
+$content = gh api graphql -F owner=$repositoryOwner -F name=$repositoryName -f query=$query | ConvertFrom-Json -ashashtable
+Write-Output "content=$content"
+
+$addedToMergeQueue = $content.data.repository.pullRequest.timelineItems.totalCount -gt 0
+Write-Output "addedToMergeQueue=$addedToMergeQueue"
+
+Set-GitHubOutput 'added-to-merge-queue' $addedToMergeQueue

--- a/.github/actions/check-merge-queue-adds/action.yml
+++ b/.github/actions/check-merge-queue-adds/action.yml
@@ -1,0 +1,29 @@
+name: Check Merge Queue Adds
+description: >
+  Checks current pull request timeline add events to determine if it was ever added to a 
+  merge queue. Intentionally not documented in Actions.md since it's only meant for 
+  internal use.
+
+outputs:
+  added-to-merge-queue:
+    description: "A boolean value indicating if pull request added to merge queue."
+    value: ${{ steps.check-merge-queue-adds.outputs.added-to-merge-queue }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Scripts
+      shell: pwsh
+      run: |
+        "${{ github.action_path }}" >> $Env:GITHUB_PATH
+        (Resolve-Path "${{ github.action_path }}/../../../Scripts").Path >> $Env:GITHUB_PATH
+
+    - name: Check Merge Queue Adds
+      id: check-merge-queue-adds
+      shell: pwsh
+      run: |
+        $parameters = @{
+            Repository = '${{ github.repository }}'
+            PullRequestNumber = '${{ github.event.pull_request.number }}'
+        }
+        Test-PullRequestMergeQueueAdds @parameters

--- a/.github/actions/verify-gha-refs/Check-Called-GHA-Refs.ps1
+++ b/.github/actions/verify-gha-refs/Check-Called-GHA-Refs.ps1
@@ -24,7 +24,7 @@ if ($mismatchRefs.Count -gt 0)
     Write-Output '> :warning: Warning :warning:' >> $env:GITHUB_STEP_SUMMARY
     Write-Output '> Your pull request branch may be outdated if you see errors for files you did not edit. Please merge the target branch to resolve these errors.' >> $env:GITHUB_STEP_SUMMARY
 
-    Write-Output "" >> $env:GITHUB_STEP_SUMMARY
+    Write-Output '' >> $env:GITHUB_STEP_SUMMARY
 
     "These called GitHub Actions and Workflows do not match expected ref '$ExpectedRef'." >> $env:GITHUB_STEP_SUMMARY
 

--- a/.github/actions/verify-gha-refs/Check-Called-GHA-Refs.ps1
+++ b/.github/actions/verify-gha-refs/Check-Called-GHA-Refs.ps1
@@ -24,6 +24,8 @@ if ($mismatchRefs.Count -gt 0)
     Write-Output '> :warning: Warning :warning:' >> $env:GITHUB_STEP_SUMMARY
     Write-Output '> Your pull request branch may be outdated if you see errors for files you did not edit. Please merge the target branch to resolve these errors.' >> $env:GITHUB_STEP_SUMMARY
 
+    Write-Output "" >> $env:GITHUB_STEP_SUMMARY
+
     "These called GitHub Actions and Workflows do not match expected ref '$ExpectedRef'." >> $env:GITHUB_STEP_SUMMARY
 
     foreach ($mismatch in $mismatchRefs)

--- a/.github/workflows/validate-this-gha-refs.yml
+++ b/.github/workflows/validate-this-gha-refs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check Merge Queue Adds
         id: check-merge-queue-adds
         if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
-        uses: LavaTG/LGHA/.github/actions/check-merge-queue-adds@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/check-merge-queue-adds@issue/OSOE-517
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/validate-this-gha-refs.yml
+++ b/.github/workflows/validate-this-gha-refs.yml
@@ -101,11 +101,11 @@ jobs:
 
       - name: Verify GitHub Actions Items Match Expected Ref (Pull & Approve/Merge PR)
         if: (github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'merge_group') && steps.add-prefix.outputs.prefixed-files != '@()'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@issue/OSOE-517
         with:
           called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
           expected-ref: ${{ steps.determine-ref.outputs.expected-ref }}
 
       - name: Verify GitHub Actions Items Match Expected Ref (Push)
         if: github.event_name == 'push'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@issue/OSOE-517

--- a/.github/workflows/validate-this-gha-refs.yml
+++ b/.github/workflows/validate-this-gha-refs.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
   pull_request_review:
     types: [submitted]
+  merge_group:
 
 jobs:
   validate-gha-refs:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout Repository (Pull & Approved PR)
-        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+      - name: Checkout Repository (Pull & Approve/Merge PR)
+        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'merge_group'
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -21,35 +22,44 @@ jobs:
         if: github.event_name == 'push'
         uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
 
+      - name: Check Merge Queue Adds
+        id: check-merge-queue-adds
+        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        uses: LavaTG/LGHA/.github/actions/check-merge-queue-adds@dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Determine Diff-Filter for Git File Changes
         id: git-diff-filter
-        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'merge_group'
         shell: pwsh
         run: |
-          $filter = ("${{ github.event_name }}" -eq 'pull_request_review') ? 'CMRT' : 'ACMRT'
+          $eventName = "${{ github.event_name }}"
+          $mergeQueueApproved = "${{ steps.check-merge-queue-adds.outputs.added-to-merge-queue }}"
+          $filter = ($eventName -eq 'pull_request_review' -or $eventName -eq 'merge_group' -or ($eventName -eq 'pull_request' -and $mergeQueueApproved -eq 'True')) ? 'CMRT' : 'ACMRT'
           $output = "git-diff-filter=$filter"
           Write-Output "output=$output"
           $output >> $env:GITHUB_OUTPUT
 
       - name: Get Applicable Git File Changes
         id: git-diff
-        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'merge_group'
         uses: Lombiq/GitHub-Actions/.github/actions/get-changed-files-from-git-diff@dev
         with:
-          left-commit: ${{ github.event.pull_request.base.sha }}
+          left-commit: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
           right-commit: ${{ github.sha }}
           diff-filter: ${{ steps.git-diff-filter.outputs.git-diff-filter }}
 
       - name: Get GitHub Actions Item Changes from File Changes
         id: changed-items
-        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'merge_group'
         uses: Lombiq/GitHub-Actions/.github/actions/get-changed-gha-items@dev
         with:
           file-include-list: '${{ steps.git-diff.outputs.changed-files }}'
 
       - name: Prefix File Names with Owner/Repo Name
         id: add-prefix
-        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'merge_group'
         shell: pwsh
         run: |
           $prefix = "${{ github.repository }}"
@@ -68,32 +78,33 @@ jobs:
 
       - name: Determine Expected Ref for GitHub Actions Files
         id: determine-ref
-        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+        if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')  || github.event_name == 'merge_group'
         shell: pwsh
         run: |
-          $headRef = "${{ github.head_ref }}"
-          $baseRef = "${{ github.base_ref }}"
+          $headRef = "${{ github.event_name == 'merge_group' && github.event.merge_group.head_ref || github.head_ref }}"
+          $baseRef = "${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.base_ref }}"
+
+          # for merge group, the refs are the full path rather than just the branch name
+          $headRef = $headRef.replace('refs/heads/', '')
+          $baseRef = $baseRef.replace('refs/heads/', '')
+
+          $eventName = "${{ github.event_name }}"
+          $skipReviewApproval = 'True'
           $lastReviewApproved = "${{ steps.check-pr-reviews.outputs.last-review-approved }}"
+          $mergeQueueApproved = "${{ steps.check-merge-queue-adds.outputs.added-to-merge-queue }}"
 
           # Ternary operator syntax available starting in PowerShell 7.0.
-          $expectedRef = ($lastReviewApproved -eq 'True') ? $baseRef : $headRef
+          $expectedRef = (($skipReviewApproval -eq 'False' -and $lastReviewApproved -eq 'True') -or $eventName -eq 'merge_group' -or ($eventName -eq 'pull_request' -and $mergeQueueApproved -eq 'True')) ? $baseRef : $headRef
 
           $output = "expected-ref=$expectedRef"
           $output >> $env:GITHUB_OUTPUT
 
-      - name: Verify GitHub Actions Items Match Expected Ref (Pull)
-        if: github.event_name == 'pull_request' && steps.add-prefix.outputs.prefixed-files != '@()'
+      - name: Verify GitHub Actions Items Match Expected Ref (Pull & Approve/Merge PR)
+        if: (github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'merge_group') && steps.add-prefix.outputs.prefixed-files != '@()'
         uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
         with:
           called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
           expected-ref: ${{ steps.determine-ref.outputs.expected-ref }}
-
-      - name: Verify GitHub Actions Items Match Expected Ref (Approved PR)
-        if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && steps.add-prefix.outputs.prefixed-files != '@()'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
-        with:
-          called-repo-base-include-list: '${{ steps.add-prefix.outputs.prefixed-files }}'
-          expected-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Verify GitHub Actions Items Match Expected Ref (Push)
         if: github.event_name == 'push'

--- a/.github/workflows/validate-this-gha-refs.yml
+++ b/.github/workflows/validate-this-gha-refs.yml
@@ -81,14 +81,25 @@ jobs:
         if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')  || github.event_name == 'merge_group'
         shell: pwsh
         run: |
-          $headRef = "${{ github.event_name == 'merge_group' && github.event.merge_group.head_ref || github.head_ref }}"
-          $baseRef = "${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.base_ref }}"
-
-          # for merge group, the refs are the full path rather than just the branch name
-          $headRef = $headRef.replace('refs/heads/', '')
-          $baseRef = $baseRef.replace('refs/heads/', '')
-
           $eventName = "${{ github.event_name }}"
+
+          if ($eventName -eq 'merge_group') {
+            $headRef = "${{ github.event.merge_group.head_ref }}"
+            $baseRef = "${{ github.event.merge_group.base_ref }}"
+
+            # For merge group context, the refs are the full path rather than just the branch name, so adjust.
+            $headRef = $headRef.replace('refs/heads/', '')
+            $baseRef = $baseRef.replace('refs/heads/', '')
+          }
+          elseif ($eventName -eq 'pull_request_review') {
+            $headRef = "${{ github.event.pull_request.head.ref }}"
+            $baseRef = "${{ github.event.pull_request.base.ref }}"
+          }
+          else {
+            $headRef = "${{ github.head_ref }}"
+            $baseRef = "${{ github.base_ref }}"
+          }
+
           $skipReviewApproval = 'True'
           $lastReviewApproved = "${{ steps.check-pr-reviews.outputs.last-review-approved }}"
           $mergeQueueApproved = "${{ steps.check-merge-queue-adds.outputs.added-to-merge-queue }}"


### PR DESCRIPTION
Adds support for merge queues to run the [`validate-this-gha-refs` workflow](https://github.com/Lombiq/GitHub-Actions/blob/dev/.github/workflows/validate-this-gha-refs.yml) when a pull request is added to the merge group, if the repository is configured for it.

Adds a `skipReviewApproval` flag to the [`Determine Expected Ref for GitHub Actions Files` step](https://github.com/Lombiq/GitHub-Actions/blob/dev/.github/workflows/validate-this-gha-refs.yml#L69) of the `validate-this-gha-refs` workflow that changes the default behavior of expecting the base branch ref (e.g. `@dev`) when the Pull Request is approved (using GitHub's pull request review feature). This allows additional commits on the PR branch after review approval but before adding the PR to the merge queue.

Here is a reminder on how the `validate-this-gha-refs` currently behaves:
1. When a PR is submitted and/or has additional commits, and prior to PR Approval, the expected refs are the target branch e.g. `@issue/[OSOE-517](https://lombiq.atlassian.net/browse/OSOE-517)`.
2. After PR Review approval, the expected refs are the base branch e.g. `@dev` so that the developer or reviewer can make sure the refs are changed back to `dev` prior to merging the pull request.

Here is how this PR changes the `validate-this-gha-refs` behavior:
1. Same as above. When a PR is submitted and/or has additional commits, and prior to PR Approval, the expected refs are the target branch e.g. `@issue/[OSOE-517](https://lombiq.atlassian.net/browse/OSOE-517)`.
2. If and only if, the [`skipReviewApproval` flag](https://github.com/Lombiq/GitHub-Actions/blob/issue/[OSOE-517](https://lombiq.atlassian.net/browse/OSOE-517)/.github/workflows/validate-this-gha-refs.yml#L92) is set to False, will the behavior be the same as above. After PR approval, the expected refs are the base branch e.g. `@dev` so that the developer or reviewer can make sure the refs are changed back to `dev` prior to merging the pull request.
3. For LGHA, [`skipReviewApproval` flag](https://github.com/Lombiq/GitHub-Actions/blob/issue/[OSOE-517](https://lombiq.atlassian.net/browse/OSOE-517)/.github/workflows/validate-this-gha-refs.yml#L92) is set to True to align with how PRs can get a PR Review approval but receive additional commits before wanting to enforce the base branch refs, e.g. `@dev`.
4. Enforcing the base branch ref (e.g. `@dev`) happens after the PR is added to the merge queue (i.e. when the "Merge When Ready" button is clicked. **NOTE** I believe for this to work, you have to configure the merge queue to run the `validate-this-gha-refs` workflow as a status check.

This PR essentially changes the "signal" for approval from PR Review Approval to adding it to the Merge Queue (clicking the Merge When Ready button).

[OSOE-517]: https://lombiq.atlassian.net/browse/OSOE-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ