### PR TITLE
GOV-29: Fixing NuGet publishing failing due to GitHub runners now having NuGet.org registered as a package source

### DIFF
--- a/.github/actions/publish-nuget/Add-SourceLinkPackage.ps1
+++ b/.github/actions/publish-nuget/Add-SourceLinkPackage.ps1
@@ -7,7 +7,7 @@ if (-not $existingSource)
 }
 else
 {
-    Write-Output "Package source for NuGet.org is already registered."
+    Write-Output 'Package source for NuGet.org is already registered.'
 }
 
 # Get the latest version of the package.

--- a/.github/actions/publish-nuget/Add-SourceLinkPackage.ps1
+++ b/.github/actions/publish-nuget/Add-SourceLinkPackage.ps1
@@ -1,5 +1,14 @@
-# Register NuGet.org as a package source since GitHub runners don't have it by default.
-Register-PackageSource -Name NuGet.org -Location https://api.nuget.org/v3/index.json -ProviderName NuGet
+# Register NuGet.org as a package source since GitHub runners don't necessarily have it by default.
+$existingSource = Get-PackageSource -Name NuGet.org -ErrorAction SilentlyContinue
+
+if (-not $existingSource)
+{
+    Register-PackageSource -Name NuGet.org -Location https://api.nuget.org/v3/index.json -ProviderName NuGet
+}
+else
+{
+    Write-Output "Package source for NuGet.org is already registered."
+}
 
 # Get the latest version of the package.
 $latestPackage = Find-Package -Name Microsoft.SourceLink.GitHub -Source NuGet.org | Sort-Object Version -Descending | Select-Object -First 1

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -75,7 +75,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/GOV-29
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -75,7 +75,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/GOV-29
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}


### PR DESCRIPTION
[GOV-29](https://lombiq.atlassian.net/browse/GOV-29)

[GOV-29]: https://lombiq.atlassian.net/browse/GOV-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ