### PR TITLE
OSOE-842: Removing the NuGetBuild property after adding the SourceLink package during NuGet publishing

### DIFF
--- a/.github/actions/publish-nuget/Add-SourceLinkPackage.ps1
+++ b/.github/actions/publish-nuget/Add-SourceLinkPackage.ps1
@@ -46,6 +46,11 @@ foreach ($projectFile in $projectFiles)
     # Unfortunately, this makes NuGet publishing a lot slower than using dotnet restore, and it's also more verbose
     # (without the ability to configure that verbosity).
     dotnet add $projectFile.FullName package 'Microsoft.SourceLink.GitHub' --source 'https://api.nuget.org/v3/index.json'
+
+    # The NuGetBuild property mustn't remain in the project file.
+    $projectXml = [xml](Get-Content $projectFile)
+    $projectXml.Project.RemoveChild($projectXml.Project.FirstChild)
+    $projectXml.Save($projectFile)
 }
 
 Write-Output 'SourceLink package added to all projects.'

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -121,6 +121,8 @@ runs:
     - name: Build
       uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
       # Notes on the configuration:
+      # * -p:NuGetBuild=true is our property to load Lombiq dependencies from NuGet by switching project references
+      #   to package references.
       # * -p:GenerateDocumentationFile=True is for generating XML doc files. Needed both for build and pack. It'd
       #   cause CS* warnings but we handle that centrally from .NET Analyzers so disabling them here.
       # * VSTHRD* rules come from somewhere unknown, disabling them.
@@ -136,6 +138,7 @@ runs:
         # solution, or fail if there are multiple projects".
         solution-or-project-path: ""
         dotnet-build-switches: |
+          -p:NuGetBuild=true
           -p:LangVersion=Latest
           -p:GenerateDocumentationFile=True
           -p:NoWarn=CS1573%3BCS1591%3BVSTHRD002%3BVSTHRD200
@@ -180,6 +183,7 @@ runs:
             "--no-restore",
             "--output:" + (Join-Path $PWD artifacts),
             "--verbosity:${{ inputs.verbosity }}",
+            "-p:NuGetBuild=true",
             "-p:LangVersion=Latest",
             "-p:Version=${{ steps.setup.outputs.publish-version }}",
             "-p:NuspecProperties=version=${{ steps.setup.outputs.publish-version }}",

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -198,9 +198,9 @@ runs:
 
         New-NuGetPackage @parameters
 
-    # - name: Push with dotnet
-    #   shell: pwsh
-    #   run: dotnet nuget push artifacts/*.nupkg --api-key $Env:API_KEY --source '${{ steps.setup.outputs.source-url }}' --skip-duplicate
+    - name: Push with dotnet
+      shell: pwsh
+      run: dotnet nuget push artifacts/*.nupkg --api-key $Env:API_KEY --source '${{ steps.setup.outputs.source-url }}' --skip-duplicate
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3.1.1

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -198,9 +198,9 @@ runs:
 
         New-NuGetPackage @parameters
 
-    - name: Push with dotnet
-      shell: pwsh
-      run: dotnet nuget push artifacts/*.nupkg --api-key $Env:API_KEY --source '${{ steps.setup.outputs.source-url }}' --skip-duplicate
+    # - name: Push with dotnet
+    #   shell: pwsh
+    #   run: dotnet nuget push artifacts/*.nupkg --api-key $Env:API_KEY --source '${{ steps.setup.outputs.source-url }}' --skip-duplicate
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3.1.1

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -102,7 +102,7 @@ runs:
         Set-GitHubOutput "publish-version" $version
 
     # This also implicitly restores NuGet dependencies.
-    - name: Add Source Link package and set NuGetBuild=true
+    - name: Add Source Link package
       shell: pwsh
       run: Add-SourceLinkPackage
 

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -75,7 +75,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-842-remove-property
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -75,7 +75,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-842-remove-property
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}


### PR DESCRIPTION
[OSOE-842](https://lombiq.atlassian.net/browse/OSOE-842)
This was introduced by https://github.com/Lombiq/GitHub-Actions/pull/343.

Fixes #342 Fixes this problem: https://github.com/OrchardCMS/OrchardCore.Commerce/pull/435#discussion_r1586222758

[OSOE-842]: https://lombiq.atlassian.net/browse/OSOE-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ