### PR TITLE
OCC-245: Add the option to publish without Microsoft.SourceLink.GitHub

### DIFF
--- a/.github/actions/publish-nuget/Add-SourceLinkPackage.ps1
+++ b/.github/actions/publish-nuget/Add-SourceLinkPackage.ps1
@@ -45,7 +45,7 @@ foreach ($projectFile in $projectFiles)
     # Central Package Management (https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management).
     # Unfortunately, this makes NuGet publishing a lot slower than using dotnet restore, and it's also more verbose
     # (without the ability to configure that verbosity).
-    dotnet add $projectFile.FullName package 'Microsoft.SourceLink.GitHub' --source 'https://api.nuget.org/v3/index.json'
+    dotnet add $projectFile.FullName package 'Microsoft.SourceLink.GitHub'
 
     # The NuGetBuild property mustn't remain in the project file.
     $projectXml = [xml](Get-Content $projectFile)

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -35,6 +35,10 @@ inputs:
       https://github.com/actions/upload-artifact#retention-period for more details. Note that this only affects the
       retention of the workflow run's artifact, not the artifacts attached to the release created on GitHub; those will
       remain indefinitely.
+  add-source-link-package:
+    required: false
+    default: 'true'
+    description: If set to "true", the Microsoft.SourceLink.GitHub NuGet package is added to the projects.
 
 runs:
   using: 'composite'
@@ -113,7 +117,15 @@ runs:
     # This also implicitly restores NuGet dependencies.
     - name: Add Source Link package
       shell: pwsh
-      run: dotnet restore
+      run: |
+        if ('${{ inputs.add-source-link-package }}' -eq 'true')
+        {
+          Add-SourceLinkPackage
+        }
+        else
+        {
+          dotnet restore
+        }
 
     - name: Update package manifest version
       shell: pwsh

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -121,11 +121,11 @@ runs:
       run: |
         if ('${{ inputs.add-source-link-package }}' -eq 'true')
         {
-          Add-SourceLinkPackage
+            Add-SourceLinkPackage
         }
         else
         {
-          dotnet restore -p:NuGetBuild=true
+            dotnet restore -p:NuGetBuild=true
         }
 
     - name: Update package manifest version

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -124,7 +124,7 @@ runs:
         }
         else
         {
-          dotnet restore
+          dotnet restore -p:NuGetBuild=true
         }
 
     - name: Update package manifest version

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -113,7 +113,7 @@ runs:
     # This also implicitly restores NuGet dependencies.
     - name: Add Source Link package
       shell: pwsh
-      run: Add-SourceLinkPackage
+      run: dotnet restore
 
     - name: Update package manifest version
       shell: pwsh

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -58,6 +58,10 @@ on:
           https://github.com/actions/upload-artifact#retention-period for more details. Note that this only affects the
           retention of the workflow run's artifact, not the artifacts attached to the release created on GitHub; those
           will remain indefinitely.
+      add-source-link-package:
+        type: string
+        default: 'true'
+        description: If set to "true", the Microsoft.SourceLink.GitHub NuGet package is added to the projects.
 
 jobs:
   publish-nuget:
@@ -83,6 +87,7 @@ jobs:
           dotnet-pack-include-symbols: ${{ inputs.dotnet-pack-include-symbols }}
           publish-version: ${{ inputs.publish-version }}
           nuget-artifact-retention-days: ${{ inputs.nuget-artifact-retention-days }}
+          add-source-link-package: ${{ inputs.add-source-link-package }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -79,7 +79,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OCC-245
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -75,7 +75,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OCC-245
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}


### PR DESCRIPTION
[OCC-245](https://lombiq.atlassian.net/browse/OCC-245)
This intentionally targets `dev`, as it's not specific to OC 2.0.

Package publishing to Cloudsmith fails if Microsoft.SourceLink.GitHub was added to the project.

[OCC-245]: https://lombiq.atlassian.net/browse/OCC-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ