### PR TITLE
OSOE-1001: Adding the ability to not enable corepack before build in validate/publish-nuget too, but with the default being not enabling

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -10,6 +10,12 @@ inputs:
     required: false
     default: minimal
     description: The logging verbosity type used by the `dotnet` command.
+  # This is really only necessary to work around the https://github.com/nodejs/corepack/issues/612 corepack issue.
+  # Also see https://github.com/Lombiq/NodeJs-Extensions/issues/120.
+  enable-corepack:
+    type: string
+    default: 'false'
+    description: Indicates whether to enable Node.js corepack before the build.
   dotnet-pack-ignore-warning:
     required: false
     default: ''
@@ -142,6 +148,7 @@ runs:
       run: Update-ManifestVersion './' '${{ steps.setup.outputs.publish-version }}'
 
     - name: Enable Node corepack
+      if: inputs.enable-corepack == 'true'
       uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@dev
 
     - name: Generate nuspec file if needed

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -106,7 +106,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-1001
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -39,6 +39,12 @@ on:
         type: number
         default: 15
         description: Configuration for the timeout-minutes parameter of the workflow. 360 is GitHub's default.
+      # This is really only necessary to work around the https://github.com/nodejs/corepack/issues/612 corepack issue.
+      # Also see https://github.com/Lombiq/NodeJs-Extensions/issues/120.
+      enable-corepack:
+        type: string
+        default: 'false'
+        description: Indicates whether to enable Node.js corepack before the build.
       dotnet-pack-ignore-warning:
         type: string
         default: ''
@@ -104,6 +110,7 @@ jobs:
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}
+          enable-corepack: ${{ inputs.enable-corepack }}
           dotnet-pack-ignore-warning: ${{ inputs.dotnet-pack-ignore-warning }}
           dotnet-pack-include-symbols: ${{ inputs.dotnet-pack-include-symbols }}
           publish-version: ${{ inputs.publish-version }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -106,7 +106,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-1001
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -61,7 +61,7 @@ on:
 jobs:
   validate-nuget-publish:
     name: Validate NuGet Publish
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-1001
     with:
       cancel-workflow-on-failure: ${{ inputs.cancel-workflow-on-failure }}
       verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -61,7 +61,7 @@ on:
 jobs:
   validate-nuget-publish:
     name: Validate NuGet Publish
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-1001
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
     with:
       cancel-workflow-on-failure: ${{ inputs.cancel-workflow-on-failure }}
       verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -31,6 +31,12 @@ on:
         type: number
         default: 15
         description: Configuration for the timeout-minutes parameter of the workflow. 360 is GitHub's default.
+      # This is really only necessary to work around the https://github.com/nodejs/corepack/issues/612 corepack issue.
+      # Also see https://github.com/Lombiq/NodeJs-Extensions/issues/120.
+      enable-corepack:
+        type: string
+        default: 'false'
+        description: Indicates whether to enable Node.js corepack before the build.
       dotnet-pack-ignore-warning:
         type: string
         default: ''
@@ -61,6 +67,7 @@ jobs:
       verbosity: ${{ inputs.verbosity }}
       dotnet-version: ${{ inputs.dotnet-version }}
       timeout-minutes: ${{ inputs.timeout-minutes }}
+      enable-corepack: ${{ inputs.enable-corepack }}
       dotnet-pack-ignore-warning: ${{ inputs.dotnet-pack-ignore-warning }}
       dotnet-pack-include-symbols: ${{ inputs.dotnet-pack-include-symbols }}
       publish-version: USE_NEXT_PATCH_VERSION


### PR DESCRIPTION
[OSOE-1001](https://lombiq.atlassian.net/browse/OSOE-1001)

[OSOE-1001]: https://lombiq.atlassian.net/browse/OSOE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ