### PR TITLE
NEST-537: Adding build-configuration parameter to Azure deploy workflow

### DIFF
--- a/.github/actions/build-dotnet/action.yml
+++ b/.github/actions/build-dotnet/action.yml
@@ -9,7 +9,7 @@ inputs:
   configuration:
     required: false
     default: Release
-    description: Configuration parameter for dotnet build (e.g. Debug, Release).
+    description: Configuration parameter for dotnet build, e.g. Release (default) or Debug.
   verbosity:
     required: false
     default: quiet

--- a/.github/workflows/build-and-test-dotnet.yml
+++ b/.github/workflows/build-and-test-dotnet.yml
@@ -70,7 +70,7 @@ on:
       build-configuration:
         type: string
         default: Release
-        description: Configuration parameter for dotnet build (e.g. Debug, Release).
+        description: Configuration parameter for dotnet build, e.g. Release (default) or Debug.
       build-solution-path:
         type: string
         default: '*.sln'
@@ -263,10 +263,10 @@ jobs:
       - name: Build and Static Code Analysis
         uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
         with:
-          directory: ${{ inputs.build-directory}}
-          configuration: ${{ inputs.build-configuration}}
-          verbosity: ${{ inputs.build-verbosity}}
-          enable-code-analysis: ${{ inputs.build-enable-code-analysis}}
+          directory: ${{ inputs.build-directory }}
+          configuration: ${{ inputs.build-configuration }}
+          verbosity: ${{ inputs.build-verbosity }}
+          enable-code-analysis: ${{ inputs.build-enable-code-analysis }}
           enable-nuget-caching: ${{ inputs.build-enable-nuget-caching }}
           enable-npm-caching: ${{ inputs.build-enable-npm-caching }}
           cache-version: ${{ inputs.build-cache-version }}

--- a/.github/workflows/build-and-test-orchard-core.yml
+++ b/.github/workflows/build-and-test-orchard-core.yml
@@ -289,7 +289,7 @@ jobs:
         uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
         with:
           directory: ${{ inputs.build-directory }}
-          configuration: ${{ inputs.build-configuration}}
+          configuration: ${{ inputs.build-configuration }}
           verbosity: ${{ inputs.build-verbosity }}
           enable-code-analysis: ${{ inputs.build-enable-code-analysis }}
           enable-nuget-caching: ${{ inputs.build-enable-nuget-caching }}

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -31,6 +31,10 @@ on:
         type: string
         default: .
         description: Path to the directory where a solution file can be found.
+      build-configuration:
+        type: string
+        default: Release
+        description: Configuration parameter for dotnet build, e.g. Release (default) or Debug.
       build-verbosity:
         type: string
         default: quiet
@@ -107,6 +111,7 @@ jobs:
         uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
         with:
           directory: ${{ inputs.build-directory }}
+          configuration: ${{ inputs.build-configuration }}
           verbosity: ${{ inputs.build-verbosity }}
           enable-code-analysis: ${{ inputs.build-enable-code-analysis }}
           enable-nuget-caching: ${{ inputs.build-enable-nuget-caching }}

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -106,9 +106,9 @@ jobs:
       - name: Build and Static Code Analysis
         uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
         with:
-          directory: ${{ inputs.build-directory}}
-          verbosity: ${{ inputs.build-verbosity}}
-          enable-code-analysis: ${{ inputs.build-enable-code-analysis}}
+          directory: ${{ inputs.build-directory }}
+          verbosity: ${{ inputs.build-verbosity }}
+          enable-code-analysis: ${{ inputs.build-enable-code-analysis }}
           enable-nuget-caching: ${{ inputs.build-enable-nuget-caching }}
           enable-npm-caching: ${{ inputs.build-enable-npm-caching }}
           cache-version: ${{ inputs.build-cache-version }}

--- a/.github/workflows/deploy-to-azure-app-service.yml
+++ b/.github/workflows/deploy-to-azure-app-service.yml
@@ -95,6 +95,10 @@ on:
         required: true
         type: string
         description: What you see at the top of the blade on the Azure Portal. Can contain uppercase letters too.
+      build-configuration:
+        type: string
+        default: Release
+        description: The build configuration to use, e.g. Release (default) or Debug.
       slot-name:
         required: true
         type: string
@@ -207,7 +211,7 @@ jobs:
         run: |
           dotnet publish (Get-ChildItem ${{ inputs.web-project-path }}).FullName `
             --no-build `
-            --configuration Release `
+            --configuration ${{ inputs.build-configuration }} `
             --output '${{ inputs.build-directory }}/Published' `
             --verbosity ${{ inputs.build-verbosity }} `
             --self-contained ${{ inputs.self-contained }} `

--- a/.github/workflows/deploy-to-azure-app-service.yml
+++ b/.github/workflows/deploy-to-azure-app-service.yml
@@ -58,6 +58,10 @@ on:
         type: string
         default: .
         description: Path to the directory where a solution file can be found.
+      build-configuration:
+        type: string
+        default: Release
+        description: Configuration parameter for dotnet build, e.g. Release (default) or Debug.
       build-verbosity:
         type: string
         default: quiet
@@ -95,10 +99,6 @@ on:
         required: true
         type: string
         description: What you see at the top of the blade on the Azure Portal. Can contain uppercase letters too.
-      build-configuration:
-        type: string
-        default: Release
-        description: The build configuration to use, e.g. Release (default) or Debug.
       slot-name:
         required: true
         type: string
@@ -191,6 +191,7 @@ jobs:
         uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
         with:
           directory: ${{ inputs.build-directory }}
+          configuration: ${{ inputs.build-configuration }}
           verbosity: ${{ inputs.build-verbosity }}
           enable-code-analysis: ${{ inputs.build-enable-code-analysis }}
           enable-nuget-caching: ${{ inputs.build-enable-nuget-caching }}


### PR DESCRIPTION
[NEST-537](https://lombiq.atlassian.net/browse/NEST-537)

Disregard the `validate-gha-refs` failure: The change that triggers it is the addition of a parameter whose default value doesn't change the overall behavior.

[NEST-537]: https://lombiq.atlassian.net/browse/NEST-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ