### PR TITLE
OSOE-1105: Disable NU5104 (\"A stable release of a package should not have a prerelease dependency.\") only for validate-nuget-publish

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -241,6 +241,17 @@ runs:
             Write-Output "::notice::Dry run mode: Package created successfully but will not be published."
         }
 
+    - name: Push with dotnet
+      if: inputs.dry-run != 'true'
+      shell: pwsh
+      run: |
+        if ([string]::IsNullOrWhiteSpace($Env:API_KEY))
+        {
+            Write-Output "::error::API_KEY is missing or empty."
+            exit 1
+        }
+        dotnet nuget push artifacts/*.nupkg --api-key $Env:API_KEY --source '${{ steps.setup.outputs.source-url }}' --skip-duplicate
+
     - name: Publish Artifacts
       uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
       with:

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -193,8 +193,6 @@ runs:
     - name: Pack
       shell: pwsh
       # Notes on the configuration apart from what's also for dotnet build:
-      # * NoWarn on NU5104 to not have warnings for prerelease dependencies, see:
-      #   https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104.
       # * -p:WarnOnPackingNonPackableProject=True will cause a build warning (converted to error) if we try to pack a
       #   non-packable project.
       # * -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg are needed to generate symbol packages:
@@ -202,7 +200,7 @@ runs:
       # * p:EnablePackageValidation=true is for package validation, see:
       #   https://docs.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview.
       run: |
-        $noWarn = @('NU5104%3BCS1573%3BCS1591%3BVSTHRD002%3BVSTHRD200') + @'
+        $noWarn = @('CS1573%3BCS1591%3BVSTHRD002%3BVSTHRD200') + @'
         ${{ inputs.dotnet-pack-ignore-warning }}
         '@.Split() | ? { $_ }
 

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -241,17 +241,6 @@ runs:
             Write-Output "::notice::Dry run mode: Package created successfully but will not be published."
         }
 
-    - name: Push with dotnet
-      if: inputs.dry-run != 'true'
-      shell: pwsh
-      run: |
-        if ([string]::IsNullOrWhiteSpace($Env:API_KEY))
-        {
-            Write-Output "::error::API_KEY is missing or empty."
-            exit 1
-        }
-        dotnet nuget push artifacts/*.nupkg --api-key $Env:API_KEY --source '${{ steps.setup.outputs.source-url }}' --skip-duplicate
-
     - name: Publish Artifacts
       uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
       with:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -106,7 +106,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-1105
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -106,7 +106,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-1105
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -61,7 +61,7 @@ on:
 jobs:
   validate-nuget-publish:
     name: Validate NuGet Publish
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-1105
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
     with:
       cancel-workflow-on-failure: ${{ inputs.cancel-workflow-on-failure }}
       verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -61,7 +61,7 @@ on:
 jobs:
   validate-nuget-publish:
     name: Validate NuGet Publish
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-1105
     with:
       cancel-workflow-on-failure: ${{ inputs.cancel-workflow-on-failure }}
       verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -71,7 +71,7 @@ jobs:
       # NoWarn on NU5104 to not have warnings for prerelease dependencies for non-prerelease versions (see
       # https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104) since those are fine during just
       # the validation stage (they should only be avoided for actual non-prerelease publishes).
-      dotnet-pack-ignore-warning: '${{ inputs.dotnet-pack-ignore-warning }}%3BNU5104'
+      dotnet-pack-ignore-warning: ${{ inputs.dotnet-pack-ignore-warning }}%3BNU5104
       dotnet-pack-include-symbols: ${{ inputs.dotnet-pack-include-symbols }}
       publish-version: USE_NEXT_PATCH_VERSION
       nuget-artifact-retention-days: ${{ inputs.nuget-artifact-retention-days }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -68,7 +68,10 @@ jobs:
       dotnet-version: ${{ inputs.dotnet-version }}
       timeout-minutes: ${{ inputs.timeout-minutes }}
       enable-corepack: ${{ inputs.enable-corepack }}
-      dotnet-pack-ignore-warning: ${{ inputs.dotnet-pack-ignore-warning }}
+      # NoWarn on NU5104 to not have warnings for prerelease dependencies for non-prerelease versions (see
+      # https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104) since those are fine during just
+      # the validation stage (they should only be avoided for actual non-prerelease publishes).
+      dotnet-pack-ignore-warning: '${{ inputs.dotnet-pack-ignore-warning }}%3BNU5104'
       dotnet-pack-include-symbols: ${{ inputs.dotnet-pack-include-symbols }}
       publish-version: USE_NEXT_PATCH_VERSION
       nuget-artifact-retention-days: ${{ inputs.nuget-artifact-retention-days }}


### PR DESCRIPTION
A demonstration of the check working is here: https://github.com/Lombiq/UI-Testing-Toolbox/actions/runs/14695120935

[OSOE-1105](https://lombiq.atlassian.net/browse/OSOE-1105)

[OSOE-1105]: https://lombiq.atlassian.net/browse/OSOE-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ