### PR TITLE
OSOE-1252: Update dependencies: WarpBuilds/cache v1.4.10, renovatebot/github-action v46.1.6, azure/webapps-deploy v3.0.8 + lock file maintenance

### DIFF
--- a/.github/actions/asset-lint/css/package-lock.json
+++ b/.github/actions/asset-lint/css/package-lock.json
@@ -678,12 +678,12 @@
       }
     },
     "node_modules/hashery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
-      "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.14.0"
+        "hookified": "^1.15.0"
       },
       "engines": {
         "node": ">=20"
@@ -1009,9 +1009,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/.github/actions/asset-lint/js/package-lock.json
+++ b/.github/actions/asset-lint/js/package-lock.json
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -592,9 +592,9 @@
       }
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.0.tgz",
-      "integrity": "sha512-3D3pEMcGKfENC9Pzlkr67GOm+205+5hRdYPZvHuNIy5sr9k0ybSU8g+sxOO/R/RLEh/gWZ3UlY+5LmEyZ1xgXQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.1.tgz",
+      "integrity": "sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -707,17 +707,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
-      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
+      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/type-utils": "8.57.1",
-        "@typescript-eslint/utils": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/type-utils": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -730,7 +730,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.1",
+        "@typescript-eslint/parser": "^8.57.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -746,16 +746,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
-      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
+      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -771,14 +771,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
-      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.1",
-        "@typescript-eslint/types": "^8.57.1",
+        "@typescript-eslint/tsconfig-utils": "^8.57.2",
+        "@typescript-eslint/types": "^8.57.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -793,14 +793,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
-      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
+      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1"
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -811,9 +811,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
-      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -828,15 +828,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
-      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
+      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -853,9 +853,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
-      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
+      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -867,16 +867,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
-      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.1",
-        "@typescript-eslint/tsconfig-utils": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/project-service": "8.57.2",
+        "@typescript-eslint/tsconfig-utils": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -947,16 +947,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
-      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
+      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1"
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -971,13 +971,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
-      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/types": "8.57.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1107,6 +1107,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1121,6 +1124,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1135,6 +1141,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1149,6 +1158,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1163,6 +1175,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,6 +1192,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,6 +1209,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1205,6 +1226,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1564,9 +1588,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
+      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1695,9 +1719,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
       "dev": true,
       "funding": [
         {
@@ -1949,9 +1973,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.325",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
+      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2526,9 +2550,9 @@
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3122,9 +3146,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4022,9 +4046,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4352,9 +4376,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4954,9 +4978,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4998,9 +5022,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5174,16 +5198,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
-      "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
+      "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.57.1",
-        "@typescript-eslint/parser": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/utils": "8.57.1"
+        "@typescript-eslint/eslint-plugin": "8.57.2",
+        "@typescript-eslint/parser": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/.github/actions/asset-lint/md/package-lock.json
+++ b/.github/actions/asset-lint/md/package-lock.json
@@ -121,9 +121,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
+      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -477,9 +477,9 @@
       "license": "MIT"
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -656,9 +656,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -1534,12 +1534,12 @@
       }
     },
     "node_modules/hashery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
-      "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.14.0"
+        "hookified": "^1.15.0"
       },
       "engines": {
         "node": ">=20"
@@ -1601,9 +1601,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1909,9 +1909,9 @@
       "license": "MIT"
     },
     "node_modules/katex": {
-      "version": "0.16.38",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.38.tgz",
-      "integrity": "sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ==",
+      "version": "0.16.42",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.42.tgz",
+      "integrity": "sha512-sZ4jqyEXfHTLEFK+qsFYToa3UZ0rtFcPGwKpyiRYh2NJn8obPWOQ+/u7ux0F6CAU/y78+Mksh1YkxTPXTh47TQ==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -4083,9 +4083,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/.github/actions/auto-merge-pull-request/action.yml
+++ b/.github/actions/auto-merge-pull-request/action.yml
@@ -23,7 +23,7 @@ runs:
       id: check-mergeability
       # Fork PR runs won't have permissions to remove labels, nor do we want to allow auto-merging them.
       if: github.event.pull_request.head.repo.fork == false
-      uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-labels@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-labels@issue/OSOE-1252
       with:
         label1: merge-if-checks-succeed
         label2: merge-and-resolve-jira-issue-if-checks-succeed
@@ -37,7 +37,7 @@ runs:
 
     - name: Remove Label
       if: steps.check-mergeability.outputs.contains-label == 'true'
-      uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1252
       with:
         token: ${{ env.GITHUB_TOKEN }}
         labels: merge-if-checks-succeed

--- a/.github/actions/auto-transition-jira-issue/action.yml
+++ b/.github/actions/auto-transition-jira-issue/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Check if Should Done
       id: check-done
-      uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-labels@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-labels@issue/OSOE-1252
       with:
         label1: done-jira-issue-if-checks-succeed
         label2: dummy
@@ -23,7 +23,7 @@ runs:
     - name: Check if Should Resolve
       id: check-resolve
       if: steps.check-done.outputs.contains-label == 'false'
-      uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-labels@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-labels@issue/OSOE-1252
       with:
         label1: resolve-jira-issue-if-checks-succeed
         label2: merge-and-resolve-jira-issue-if-checks-succeed
@@ -41,7 +41,7 @@ runs:
         Set-JiraIssueStatus @parameters
 
     - name: Remove Label
-      uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1252
       with:
         token: ${{ env.GITHUB_TOKEN }}
         labels: merge-and-resolve-jira-issue-if-checks-succeed, resolve-jira-issue-if-checks-succeed, done-jira-issue-if-checks-succeed

--- a/.github/actions/build-dotnet/action.yml
+++ b/.github/actions/build-dotnet/action.yml
@@ -212,7 +212,7 @@ runs:
         Write-Output ("Solution or project build took {0:0.###} seconds." -f ($endTime - $startTime).TotalSeconds)
 
     - name: Upload MSBuild Binary Log
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       if: (success() || failure()) && inputs.create-binary-log == 'true'
       with:
         name: build-binary-log-${{ steps.build.outputs.artifact-name-suffix }}.binlog

--- a/.github/actions/build-dotnet/action.yml
+++ b/.github/actions/build-dotnet/action.yml
@@ -146,7 +146,7 @@ runs:
         restore-keys: ${{ steps.detect-cache-configuration.outputs.restore-keys }}
 
     - name: Cache Packages with WarpBuild Cache
-      uses: WarpBuilds/cache@8f10197bad216ec3a6ba6188e7e41e5f52f894cc # v1.4.7
+      uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1.4.10
       if: steps.detect-cache-configuration.outputs.cache-enabled == 'true' && contains(runner.name, 'warp')
       with:
         path: ${{ format(steps.detect-cache-configuration.outputs.paths, fromJSON('"\n"')) }}

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -36,7 +36,7 @@ runs:
         (Resolve-Path '${{ github.action_path }}/../../../Scripts').Path >> $Env:GITHUB_PATH
 
     - name: Set Checkout Token
-      uses: Lombiq/GitHub-Actions/.github/actions/set-checkout-token@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/set-checkout-token@issue/OSOE-1252
       with:
         checkout-token: ${{ inputs.token }}
 

--- a/.github/actions/create-timestamp/action.yml
+++ b/.github/actions/create-timestamp/action.yml
@@ -1,4 +1,4 @@
-﻿name: Create Timestamp
+name: Create Timestamp
 description: >
   Create a timestamp in ISO 8601 format for use in tags (replaces ":" with "." for use in git tags). Intentionally not
   documented in Actions.md since it's only meant for internal use.

--- a/.github/actions/mark-breaking-changes/action.yml
+++ b/.github/actions/mark-breaking-changes/action.yml
@@ -18,7 +18,7 @@ runs:
         (Resolve-Path '${{ github.action_path }}/../../../Scripts').Path >> $Env:GITHUB_PATH
 
     - name: Update Breaking Changes Label
-      uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1252
       with:
         token: ${{ env.GITHUB_TOKEN }}
         label: breaking-changes

--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -64,7 +64,7 @@ runs:
         Set-GitHubOutput 'artifact-path' $artifactFolder
 
     - name: Upload files fixed by markdown-lint
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       if: inputs.fix == 'true' && steps.markdown-lint-fix-files.outputs.has-fixes == 'true'
       with:
         name: markdown-lint-fixed-files

--- a/.github/actions/mirror-branches/action.yml
+++ b/.github/actions/mirror-branches/action.yml
@@ -71,7 +71,7 @@ runs:
 
     - name: Get source branches
       id: get-source-branches
-      uses: Lombiq/GitHub-Actions/.github/actions/get-branches@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/get-branches@issue/OSOE-1252
       with:
         repository: ${{ inputs.source-repository }}
         # When empty, source token falls back to destination token, which still works for a public source repository.
@@ -79,7 +79,7 @@ runs:
 
     - name: Get destination branches
       id: get-destination-branches
-      uses: Lombiq/GitHub-Actions/.github/actions/get-branches@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/get-branches@issue/OSOE-1252
       with:
         repository: ${{ inputs.destination-repository }}
         api-token: ${{ inputs.destination-token }}
@@ -100,7 +100,7 @@ runs:
 
     - name: Checkout source repository
       if: steps.find-branches.outputs.first-branch-name != ''
-      uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
       with:
         repository: ${{ inputs.source-repository }}
         ref: ${{ steps.find-branches.outputs.first-branch-name }}

--- a/.github/actions/msbuild/action.yml
+++ b/.github/actions/msbuild/action.yml
@@ -96,7 +96,7 @@ runs:
         Write-Output ("Solution or project build took {0:0.###} seconds." -f ($endTime - $startTime).TotalSeconds)
 
     - name: Upload MSBuild Binary Log
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       if: (success() || failure()) && inputs.create-binary-log == 'true'
       with:
         name: build-binary-log.binlog

--- a/.github/actions/precompile-orchard1-app/action.yml
+++ b/.github/actions/precompile-orchard1-app/action.yml
@@ -53,7 +53,7 @@ runs:
   steps:
     - name: Checkout
       if: inputs.repository != ''
-      uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.checkout-ref }}
@@ -61,7 +61,7 @@ runs:
         path: ${{ inputs.checkout-path }}
 
     - name: Enable Node corepack
-      uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@issue/OSOE-1252
 
     # Calling nuget restore separately on the actual solution, because we're passing Orchard.proj to the msbuild action
     # instead to be able to call the Precompiled target on it.
@@ -70,7 +70,7 @@ runs:
       run: nuget restore ${{ inputs.checkout-path }}/${{ inputs.solution-path }}
 
     - name: Publish Precompiled app
-      uses: Lombiq/GitHub-Actions/.github/actions/msbuild@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/msbuild@issue/OSOE-1252
       with:
         directory: ${{ inputs.checkout-path }}
         verbosity: ${{ inputs.verbosity }}

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -154,7 +154,7 @@ runs:
 
     - name: Enable Node corepack
       if: inputs.enable-corepack == 'true'
-      uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@issue/OSOE-1252
 
     - name: Generate nuspec file if needed
       if: hashFiles('ConvertTo-Nuspec.ps1')
@@ -162,7 +162,7 @@ runs:
       run: ./ConvertTo-Nuspec.ps1 '${{ steps.setup.outputs.publish-version }}'
 
     - name: Build
-      uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@issue/OSOE-1252
       # Notes on the configuration:
       # * -p:NuGetBuild=true is our property to load Lombiq dependencies from NuGet by switching project references
       #   to package references.
@@ -269,7 +269,7 @@ runs:
     - name: Check for ignore-breaking-changes Label
       id: check-ignore-breaking
       if: ${{ (failure() || success()) && inputs.mark-breaking-changes == 'true' && github.event_name == 'pull_request' }}
-      uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-labels@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-labels@issue/OSOE-1252
       with:
         label1: ignore-breaking-changes
 
@@ -277,14 +277,14 @@ runs:
       if: ${{ (failure() || success()) &&
         inputs.mark-breaking-changes == 'true' &&
         github.event_name == 'pull_request' }}
-      uses: Lombiq/GitHub-Actions/.github/actions/mark-breaking-changes@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/mark-breaking-changes@issue/OSOE-1252
       with:
         is-breaking: ${{ steps.check-ignore-breaking.outputs.contains-label == 'true' && 'false' || steps.pack.outputs.is-breaking == 'true' }}
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
     - name: Upload NuGet Package Artifact
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       with:
         name: NuGet-Package
         path: artifacts
@@ -292,7 +292,7 @@ runs:
 
     - name: Upload CompatibilitySuppressions File Artifact
       if: success() || failure()
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       with:
         name: CompatibilitySuppressions
         path: CompatibilitySuppressions
@@ -300,7 +300,7 @@ runs:
         if-no-files-found: ignore
 
     - name: Create Release
-      uses: Lombiq/GitHub-Actions/.github/actions/release-action@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/release-action@issue/OSOE-1252
       # Also preventing creating releases when pushing tags for issue-specific pre-releases like v4.3.1-alpha.osoe-86.
       if: inputs.dry-run != 'true' && !contains(steps.setup.outputs.publish-version, '-')
       with:

--- a/.github/actions/remove-old-latest-tags/action.yml
+++ b/.github/actions/remove-old-latest-tags/action.yml
@@ -1,4 +1,4 @@
-﻿name: Remove Old Latest Tags
+name: Remove Old Latest Tags
 description: >
     Removes the old prefix/latest tag so that a new one can be set. Intentionally not documented in Actions.md since
     it's only meant for internal use.

--- a/.github/actions/renovate/action.yml
+++ b/.github/actions/renovate/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Run Renovate
-      uses: renovatebot/github-action@abd08c7549b2a864af5df4a2e369c43f035a6a9d # v46.1.5
+      uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6
       env:
         RENOVATE_REPOSITORIES: ${{ github.repository }}
         LOG_LEVEL: ${{ inputs.log-level }}

--- a/.github/actions/setup-azurite/action.yml
+++ b/.github/actions/setup-azurite/action.yml
@@ -1,4 +1,4 @@
-﻿name: Set up Azurite
+name: Set up Azurite
 description: >
   Sets up the Azurite for local Azure Blob Storage emulation
   (https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite) via NPM.

--- a/.github/actions/setup-sql-server/action.yml
+++ b/.github/actions/setup-sql-server/action.yml
@@ -15,7 +15,7 @@ runs:
 
     # Installs the SQL Server command-line tools if they're not present (necessary for Ubuntu 24.04-based runners).
     - name: Install sqlcmd
-      uses: Lombiq/GitHub-Actions/.github/actions/install-sqlcmd@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/install-sqlcmd@issue/OSOE-1252
 
     # Needs to be a separate step, otherwise the Chocolatey installation won't be visible.
     - name: Wait for SQL Server to start

--- a/.github/actions/test-dotnet/action.yml
+++ b/.github/actions/test-dotnet/action.yml
@@ -84,7 +84,7 @@ runs:
         Set-GitHubEnv 'Lombiq_Tests_UI__OrchardCoreUITestExecutorConfiguration__RetryIntervalSeconds' ${{ inputs.ui-test-retry-interval-seconds }}
 
     - name: Install dotnet-dump
-      uses: Lombiq/GitHub-Actions/.github/actions/install-dotnet-tool@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/install-dotnet-tool@issue/OSOE-1252
       with:
         name: dotnet-dump
         version: 8.0.510501
@@ -120,7 +120,7 @@ runs:
     # Under Windows this can fail with "ENOENT: no such file or directory" if the path is too long, see
     # https://github.com/actions/upload-artifact/issues/240.
     - name: Upload UI Testing Artifacts
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       # We don't need additional conditions, because of the "if-no-files-found" setting.
       if: (success() || failure()) && steps.run-tests.outputs.test-count != 0
       with:
@@ -139,7 +139,7 @@ runs:
     # Under Windows this can fail with "ENOENT: no such file or directory" if the path is too long, see
     # https://github.com/actions/upload-artifact/issues/240.
     - name: Upload UI Testing Artifacts
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       # We don't need additional conditions, because of the "if-no-files-found" setting.
       if: (success() || failure()) && steps.run-tests.outputs.test-count != 0
       with:
@@ -155,7 +155,7 @@ runs:
       run: Merge-BlameHangDumps -Directory "${{ inputs.build-directory }}" -Configuration "${{ inputs.test-configuration }}"
 
     - name: Upload Blame Hang Dumps
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       if: |
         failure() &&
         steps.run-tests.outputs.test-count != 0 &&
@@ -168,7 +168,7 @@ runs:
         retention-days: ${{ inputs.artifact-retention-days }}
 
     - name: Upload Dotnet Test Hang Dumps
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       if: (success() || failure()) && steps.run-tests.outputs.test-count != 0 && steps.run-tests.outputs.dotnet-test-hang-dump != 0
       with:
         name: dotnet-test-hang-dump-${{ steps.setup.outputs.artifact-name-suffix }}
@@ -177,7 +177,7 @@ runs:
         retention-days: ${{ inputs.artifact-retention-days }}
 
     - name: Upload Diagnostic Logs
-      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/upload-artifact@issue/OSOE-1252
       # always() is needed because if the test process hangs and the workflow times out, we still need the diagnostic
       # logs. We don't need additional conditions, because of the "if-no-files-found" setting.
       if: always() && steps.run-tests.outputs.test-count != 0

--- a/.github/actions/verify-dotnet-consolidation/action.yml
+++ b/.github/actions/verify-dotnet-consolidation/action.yml
@@ -39,7 +39,7 @@ runs:
         (Resolve-Path '${{ github.action_path }}/../../../Scripts').Path >> $Env:GITHUB_PATH
 
     - name: Install dotnet-consolidate
-      uses: Lombiq/GitHub-Actions/.github/actions/install-dotnet-tool@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/install-dotnet-tool@issue/OSOE-1252
       with:
         name: dotnet-consolidate
         version: 4.2.0

--- a/.github/actions/workflow-telemetry/action.yml
+++ b/.github/actions/workflow-telemetry/action.yml
@@ -59,7 +59,7 @@ runs:
   using: composite
   steps:
     - name: Set Checkout Token
-      uses: Lombiq/GitHub-Actions/.github/actions/set-checkout-token@dev
+      uses: Lombiq/GitHub-Actions/.github/actions/set-checkout-token@issue/OSOE-1252
       with:
         checkout-token: ${{ inputs.github_token }}
 

--- a/.github/workflows/asset-lint.yml
+++ b/.github/workflows/asset-lint.yml
@@ -36,15 +36,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up Node.js
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@issue/OSOE-1252
 
       - name: Lint Scripts and Styles
-        uses: Lombiq/GitHub-Actions/.github/actions/asset-lint@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/asset-lint@issue/OSOE-1252
         with:
           scripts: ${{ inputs.scripts }}
           styles: ${{ inputs.styles }}
@@ -52,6 +52,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-test-dotnet.yml
+++ b/.github/workflows/build-and-test-dotnet.yml
@@ -256,47 +256,47 @@ jobs:
       # This has to be the first step so it can collect data about the whole workflow run.
       - name: Collect Workflow Telemetry
         if: inputs.collect-workflow-telemetry == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/workflow-telemetry@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/workflow-telemetry@issue/OSOE-1252
         with:
           github_token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set Environment Variables
-        uses: Lombiq/GitHub-Actions/.github/actions/set-environment-variables@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/set-environment-variables@issue/OSOE-1252
         env:
           ENVIRONMENT_VARIABLES_JSON: ${{ secrets.ENVIRONMENT_VARIABLES_JSON }}
 
       - name: Free up Space
         if: inputs.free-up-space == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@issue/OSOE-1252
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.repository-ref }}
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-1252
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Verify that .NET packages are consolidated
         if: ${{ inputs.verify-dotnet-consolidation }}
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-dotnet-consolidation@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-dotnet-consolidation@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
           exclude-version-regex: ${{ inputs.dotnet-consolidation-exclude-version-regex }}
           exclude-project-path: ${{ inputs.dotnet-consolidation-exclude-project-path }}
 
       - name: Set up Node.js
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@issue/OSOE-1252
         with:
           node-version: ${{ inputs.node-version }}
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Build and Static Code Analysis
-        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
           configuration: ${{ inputs.build-configuration }}
@@ -312,7 +312,7 @@ jobs:
 
       - name: Tests
         if: inputs.test-disable == 'false'
-        uses: Lombiq/GitHub-Actions/.github/actions/test-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/test-dotnet@issue/OSOE-1252
         with:
           blame-hang-timeout: ${{ inputs.blame-hang-timeout }}
           build-directory: ${{ inputs.build-directory }}
@@ -327,6 +327,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-test-orchard-core.yml
+++ b/.github/workflows/build-and-test-orchard-core.yml
@@ -275,51 +275,51 @@ jobs:
       # This has to be the first step so it can collect data about the whole workflow run.
       - name: Collect Workflow Telemetry
         if: inputs.collect-workflow-telemetry == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/workflow-telemetry@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/workflow-telemetry@issue/OSOE-1252
         with:
           github_token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set Environment Variables
-        uses: Lombiq/GitHub-Actions/.github/actions/set-environment-variables@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/set-environment-variables@issue/OSOE-1252
         env:
           ENVIRONMENT_VARIABLES_JSON: ${{ secrets.ENVIRONMENT_VARIABLES_JSON }}
 
       - name: Free up Space
         if: inputs.free-up-space == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@issue/OSOE-1252
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.repository-ref }}
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-1252
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Verify that .NET packages are consolidated
         if: ${{ inputs.verify-dotnet-consolidation }}
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-dotnet-consolidation@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-dotnet-consolidation@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
           exclude-version-regex: ${{ inputs.dotnet-consolidation-exclude-version-regex }}
           exclude-project-path: ${{ inputs.dotnet-consolidation-exclude-project-path }}
 
       - name: Set up Node.js
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@issue/OSOE-1252
         with:
           node-version: ${{ inputs.node-version }}
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Enable Node.js corepack
         if: inputs.enable-corepack == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@issue/OSOE-1252
 
       - name: Build and Static Code Analysis
-        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
           configuration: ${{ inputs.build-configuration }}
@@ -335,25 +335,25 @@ jobs:
 
       - name: Print configuration summary
         if: inputs.print-config-summary == 'true' && (success() || failure())
-        uses: Lombiq/GitHub-Actions/.github/actions/print-config-summary@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/print-config-summary@issue/OSOE-1252
 
       - name: Set up SQL Server
         if: inputs.set-up-sql-server == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-sql-server@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-sql-server@issue/OSOE-1252
 
       - name: Set up Elasticsearch
         if: inputs.set-up-elasticsearch == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-elasticsearch@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-elasticsearch@issue/OSOE-1252
 
       - name: Set up Azurite
         if: inputs.set-up-azurite == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-azurite@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-azurite@issue/OSOE-1252
         with:
           location: ${{ inputs.build-directory}}
 
       - name: Tests
         if: inputs.test-disable == 'false'
-        uses: Lombiq/GitHub-Actions/.github/actions/test-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/test-dotnet@issue/OSOE-1252
         with:
           blame-hang-timeout: ${{ inputs.blame-hang-timeout }}
           build-directory: ${{ inputs.build-directory }}
@@ -368,6 +368,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -92,23 +92,23 @@ jobs:
           Write-Output '::warning::This workflow is deprecated. Use build-and-test-dotnet instead, that can also execute tests.'
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-1252
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Verify that .NET packages are consolidated
         if: ${{ inputs.verify-dotnet-consolidation }}
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-dotnet-consolidation@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-dotnet-consolidation@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
 
       - name: Build and Static Code Analysis
-        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
           configuration: ${{ inputs.build-configuration }}
@@ -120,6 +120,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codespell-this-repo.yml
+++ b/.github/workflows/codespell-this-repo.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   codespell:
     name: Codespell
-    uses: Lombiq/GitHub-Actions/.github/workflows/codespell.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/codespell.yml@issue/OSOE-1252

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Run codespell
-        uses: Lombiq/GitHub-Actions/.github/actions/codespell@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/codespell@issue/OSOE-1252
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-jira-issues-for-community-activities-in-this-repo.yml
+++ b/.github/workflows/create-jira-issues-for-community-activities-in-this-repo.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-jira-issues-for-community-activities:
     name: Create Jira issues for community activities
-    uses: Lombiq/GitHub-Actions/.github/workflows/create-jira-issues-for-community-activities.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/create-jira-issues-for-community-activities.yml@issue/OSOE-1252
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}

--- a/.github/workflows/create-jira-issues-for-community-activities.yml
+++ b/.github/workflows/create-jira-issues-for-community-activities.yml
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Create Jira issues for community activities
-        uses: Lombiq/GitHub-Actions/.github/actions/create-jira-issues-for-community-activities@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/create-jira-issues-for-community-activities@issue/OSOE-1252
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/deploy-orchard1-to-azure-app-service.yml
+++ b/.github/workflows/deploy-orchard1-to-azure-app-service.yml
@@ -153,26 +153,26 @@ jobs:
     steps:
       - name: Free up Space
         if: inputs.free-up-space == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@issue/OSOE-1252
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-1252
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Set up Node.js
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@issue/OSOE-1252
         with:
           node-version: ${{ inputs.node-version }}
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Enable Node corepack
-        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@issue/OSOE-1252
 
       # Calling nuget restore separately on the actual solution, because we're passing Orchard.proj to the msbuild
       # action instead to be able to call the Precompiled target.
@@ -180,7 +180,7 @@ jobs:
         run: nuget restore ${{ inputs.build-directory }}\${{ inputs.solution-or-project-path }}
 
       - name: Publish Precompiled App
-        uses: Lombiq/GitHub-Actions/.github/actions/msbuild@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/msbuild@issue/OSOE-1252
         with:
           solution-or-project-path: Orchard.proj
           verbosity: ${{ inputs.build-verbosity }}
@@ -191,7 +191,7 @@ jobs:
             /p:Solution=${{ inputs.build-directory }}\${{ inputs.solution-or-project-path }}
 
       - name: Login to Azure
-        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@issue/OSOE-1252
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_APP_SERVICE_DEPLOYMENT_SERVICE_PRINCIPAL_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_APP_SERVICE_DEPLOYMENT_AZURE_TENANT_ID }}
@@ -222,7 +222,7 @@ jobs:
 
       - name: Add Azure Application Insights Release Annotation
         if: ${{ inputs.application-insights-resource-id != '' }}
-        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@issue/OSOE-1252
         with:
           release-name: 'Deploy #${{ github.run_number }} to ${{ inputs.slot-name }}'
           application-insights-resource-id: ${{ inputs.application-insights-resource-id }}
@@ -255,6 +255,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-to-azure-app-service.yml
+++ b/.github/workflows/deploy-to-azure-app-service.yml
@@ -192,27 +192,27 @@ jobs:
     steps:
       - name: Free up Space
         if: inputs.free-up-space == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@issue/OSOE-1252
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-1252
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Set up Node.js
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@issue/OSOE-1252
         with:
           node-version: ${{ inputs.node-version }}
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Enable Node corepack
         if: inputs.enable-corepack == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@issue/OSOE-1252
 
       # If runtime is defined, we need to add "--runtime=" to the string so it will be a valid build/publish option. The
       # "build-dotnet" action requires the additional switches to be in separate lines (even the parameters), but we can
@@ -224,7 +224,7 @@ jobs:
           "runtime-option=--runtime=${{ inputs.runtime }}" >> $Env:GITHUB_OUTPUT
 
       - name: Build and Static Code Analysis
-        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
           configuration: ${{ inputs.build-configuration }}
@@ -263,7 +263,7 @@ jobs:
           Compress-Archive -Path .\Published\* -DestinationPath .\Published.zip
 
       - name: Login to Azure
-        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@issue/OSOE-1252
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_APP_SERVICE_DEPLOYMENT_SERVICE_PRINCIPAL_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_APP_SERVICE_DEPLOYMENT_AZURE_TENANT_ID }}
@@ -310,10 +310,10 @@ jobs:
 
       - name: Create Timestamp
         id: create-timestamp
-        uses: Lombiq/GitHub-Actions/.github/actions/create-timestamp@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/create-timestamp@issue/OSOE-1252
 
       - name: Add Azure Application Insights Release Annotation
-        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@issue/OSOE-1252
         with:
           release-name: 'Deploy #${{ github.run_number }} to ${{ inputs.slot-name }}'
           application-insights-resource-id: ${{ inputs.application-insights-resource-id }}
@@ -321,7 +321,7 @@ jobs:
 
       - name: Remove Old Latest Tags
         if: ${{ inputs.skip-update-latest-tag != 'true' }}
-        uses: Lombiq/GitHub-Actions/.github/actions/remove-old-latest-tags@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/remove-old-latest-tags@issue/OSOE-1252
         with:
           tag-prefix: ${{ inputs.tag-prefix }}
 
@@ -349,6 +349,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-to-azure-app-service.yml
+++ b/.github/workflows/deploy-to-azure-app-service.yml
@@ -284,7 +284,7 @@ jobs:
       - name: Deploy to Azure App Service
         id: deploy-to-azure
         continue-on-error: true
-        uses: azure/webapps-deploy@84a80cfe7e9889f35148ed88c307e6e93bf02578 # v3.0.7
+        uses: azure/webapps-deploy@45c7df8f6a4fe841b67ff88920b33f4f8328f8d9 # v3.0.8
         with:
           app-name: ${{ inputs.app-name }}
           slot-name: ${{ inputs.slot-name }}
@@ -297,7 +297,7 @@ jobs:
 
       - name: Deploy to Azure App Service (Retry)
         if: steps.deploy-to-azure.outcome == 'failure'
-        uses: azure/webapps-deploy@84a80cfe7e9889f35148ed88c307e6e93bf02578 # v3.0.7
+        uses: azure/webapps-deploy@45c7df8f6a4fe841b67ff88920b33f4f8328f8d9 # v3.0.8
         with:
           app-name: ${{ inputs.app-name }}
           slot-name: ${{ inputs.slot-name }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -52,12 +52,12 @@ jobs:
           Write-Output '::warning::This workflow is deprecated. Use asset-lint instead. It lints Markdown files with markdownlint and textlint too.'
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Markdown Linting
-        uses: Lombiq/GitHub-Actions/.github/actions/markdown-lint@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/markdown-lint@issue/OSOE-1252
         with:
           config: ${{ inputs.config }}
           fix: ${{ inputs.fix }}
@@ -66,6 +66,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mirror-branches.yml
+++ b/.github/workflows/mirror-branches.yml
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Mirror branches
-        uses: Lombiq/GitHub-Actions/.github/actions/mirror-branches@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/mirror-branches@issue/OSOE-1252
         with:
           source-repository: ${{ inputs.source-repository }}
           source-token: ${{ secrets.SOURCE_TOKEN }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Send Microsoft Teams failure notification
         if: failure() && env.FAILURE_NOTIFICATION_TEAMS_WEBHOOK != ''
-        uses: Lombiq/GitHub-Actions/.github/actions/notify-teams@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/notify-teams@issue/OSOE-1252
         env:
           # This is added only to be able to use it in the step's run condition.
           FAILURE_NOTIFICATION_TEAMS_WEBHOOK: ${{ secrets.FAILURE_NOTIFICATION_TEAMS_WEBHOOK }}

--- a/.github/workflows/msbuild-and-test.yml
+++ b/.github/workflows/msbuild-and-test.yml
@@ -169,43 +169,43 @@ jobs:
       # This has to be the first step so it can collect data about the whole workflow run.
       - name: Collect Workflow Telemetry
         if: inputs.collect-workflow-telemetry == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/workflow-telemetry@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/workflow-telemetry@issue/OSOE-1252
         with:
           github_token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set Environment Variables
-        uses: Lombiq/GitHub-Actions/.github/actions/set-environment-variables@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/set-environment-variables@issue/OSOE-1252
         env:
           ENVIRONMENT_VARIABLES_JSON: ${{ secrets.ENVIRONMENT_VARIABLES_JSON }}
 
       - name: Free up Space
         if: inputs.free-up-space == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@issue/OSOE-1252
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.repository-ref }}
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up Node.js
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@issue/OSOE-1252
         with:
           node-version: ${{ inputs.node-version }}
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Enable Node corepack
-        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@issue/OSOE-1252
 
       # This is necessary for building Gulp Extensions and test-dotnet.
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-1252
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Build and Static Code Analysis
-        uses: Lombiq/GitHub-Actions/.github/actions/msbuild@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/msbuild@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
           solution-or-project-path: ${{ inputs.solution-or-project-path }}
@@ -217,7 +217,7 @@ jobs:
 
       - name: Tests
         if: inputs.test-disable == 'false'
-        uses: Lombiq/GitHub-Actions/.github/actions/test-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/test-dotnet@issue/OSOE-1252
         with:
           build-directory: ${{ inputs.build-directory }}
           dotnet-test-process-timeout: ${{ inputs.dotnet-test-process-timeout }}
@@ -227,6 +227,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/open-pull-request.yml
+++ b/.github/workflows/open-pull-request.yml
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set Checkout Token
-        uses: Lombiq/GitHub-Actions/.github/actions/set-checkout-token@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/set-checkout-token@issue/OSOE-1252
         with:
           checkout-token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Open Pull Request
-        uses: Lombiq/GitHub-Actions/.github/actions/open-pull-request@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/open-pull-request@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.CHECKOUT_TOKEN }}
         with:

--- a/.github/workflows/post-pull-request-checks-automation.yml
+++ b/.github/workflows/post-pull-request-checks-automation.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Check Further Steps Should Run
         if: inputs.run-only-latest-workflow == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/check-current-workflow-is-latest@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/check-current-workflow-is-latest@issue/OSOE-1252
         id: check-steps-should-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Automatically Merge Pull Request
         if: steps.check-steps-should-run.outputs.is-latest != 'false'
-        uses: Lombiq/GitHub-Actions/.github/actions/auto-merge-pull-request@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/auto-merge-pull-request@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ env.MERGE_TOKEN }}
         with:
@@ -86,7 +86,7 @@ jobs:
 
       - name: Automatically Transition Jira issue
         if: steps.check-steps-should-run.outputs.is-latest != 'false'
-        uses: Lombiq/GitHub-Actions/.github/actions/auto-transition-jira-issue@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/auto-transition-jira-issue@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ env.MERGE_TOKEN }}
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Remove Label
         if: steps.check-steps-should-run.outputs.is-latest != 'false'
-        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1252
         with:
           token: ${{ env.MERGE_TOKEN }}
           labels: merge-and-resolve-jira-issue-if-checks-succeed

--- a/.github/workflows/post-to-x.yml
+++ b/.github/workflows/post-to-x.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
     steps:
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
 
       - name: Post
         uses: twitter-together/action@08857009da2aacd9bd08204550ec96e15d76b4da # v3.1.0

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -122,32 +122,32 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Set Environment Variables
-        uses: Lombiq/GitHub-Actions/.github/actions/set-environment-variables@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/set-environment-variables@issue/OSOE-1252
         env:
           ENVIRONMENT_VARIABLES_JSON: ${{ secrets.ENVIRONMENT_VARIABLES_JSON }}
 
       - name: Free up Space
         if: inputs.free-up-space == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/free-up-space-for-dotnet@issue/OSOE-1252
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-1252
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Set up Node.js
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@issue/OSOE-1252
         with:
           node-version: ${{ inputs.node-version }}
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-1252
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}
@@ -165,6 +165,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Run Renovate
-        uses: Lombiq/GitHub-Actions/.github/actions/renovate@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/renovate@issue/OSOE-1252
         env:
           CHECKOUT_TOKEN: ${{ secrets.CHECKOUT_TOKEN }}
         with:

--- a/.github/workflows/reset-azure-environment.yml
+++ b/.github/workflows/reset-azure-environment.yml
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Login to Azure
-        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@issue/OSOE-1252
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_APP_SERVICE_RESET_SERVICE_PRINCIPAL_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_APP_SERVICE_RESET_AZURE_TENANT_ID }}
@@ -198,7 +198,7 @@ jobs:
 
       - name: Add Azure Application Insights Release Annotation
         if: ${{ inputs.application-insights-resource-id != '' }}
-        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@issue/OSOE-1252
         with:
           release-name: 'Reset #${{ github.run_number }} from ${{ inputs.source-slot-name }} to ${{ inputs.destination-slot-name }}'
           application-insights-resource-id: ${{ inputs.application-insights-resource-id }}
@@ -248,6 +248,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -98,7 +98,7 @@ jobs:
         run: Write-Output '::warning::This workflow is deprecated. Use the codespell workflow instead.'
 
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: Check Spelling
         id: check-spelling-action
-        uses: Lombiq/GitHub-Actions/.github/actions/spelling@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/spelling@issue/OSOE-1252
         with:
           merge-file-excludes: ${{ inputs.merge-file-excludes }}
           merge-forbidden-patterns: ${{ inputs.merge-forbidden-patterns }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -142,7 +142,7 @@ jobs:
     if: always() && needs.check-spelling.outputs.followup && github.event_name == 'pull_request'
     steps:
       - name: Comment (PR)
-        uses: Lombiq/GitHub-Actions/.github/actions/spelling@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/spelling@issue/OSOE-1252
         with:
           post-comment: 1
           task: ${{ needs.check-spelling.outputs.followup }}

--- a/.github/workflows/swap-azure-web-app-slots.yml
+++ b/.github/workflows/swap-azure-web-app-slots.yml
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Login to Azure
-        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@issue/OSOE-1252
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_APP_SERVICE_SWAP_SERVICE_PRINCIPAL_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_APP_SERVICE_SWAP_AZURE_TENANT_ID }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Create Timestamp
         id: create-timestamp
-        uses: Lombiq/GitHub-Actions/.github/actions/create-timestamp@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/create-timestamp@issue/OSOE-1252
 
       - name: Test Destination Web App Slot
         run: |
@@ -148,7 +148,7 @@ jobs:
 
       - name: Checkout Code Repository
         if: inputs.app-code-repository != ''
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           repository: ${{ inputs.app-code-repository }}
           token: ${{ secrets.CODE_REPOSITORY_WRITE_TOKEN }}
@@ -215,7 +215,7 @@ jobs:
             "commit-sha=$stagingLatest" >> $Env:GITHUB_OUTPUT
 
       - name: Add Azure Application Insights Release Annotation
-        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@issue/OSOE-1252
         with:
           release-name: 'Swap #${{ github.run_number }} from ${{ inputs.source-slot-name }} to ${{ inputs.destination-slot-name }}'
           application-insights-resource-id: ${{ inputs.application-insights-resource-id }}
@@ -248,6 +248,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/swap-orchard1-azure-web-app-slots.yml
+++ b/.github/workflows/swap-orchard1-azure-web-app-slots.yml
@@ -92,7 +92,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Login to Azure
-        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/login-to-azure@issue/OSOE-1252
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_APP_SERVICE_SWAP_SERVICE_PRINCIPAL_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_APP_SERVICE_SWAP_AZURE_TENANT_ID }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Add Azure Application Insights Release Annotation
         if: ${{ inputs.application-insights-resource-id != '' }}
-        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-azure-application-insights-release-annotation@issue/OSOE-1252
         with:
           release-name: 'Swap #${{ github.run_number }} from ${{ inputs.source-slot-name }} to ${{ inputs.destination-slot-name }}'
           application-insights-resource-id: ${{ inputs.application-insights-resource-id }}
@@ -130,6 +130,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-version-this-repo.yml
+++ b/.github/workflows/tag-version-this-repo.yml
@@ -9,7 +9,7 @@ jobs:
   tag-version:
     name: Tag Version Automation
     if: github.event.pusher.name != 'LombiqBot'
-    uses: Lombiq/GitHub-Actions/.github/workflows/tag-version.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/tag-version.yml@issue/OSOE-1252
     with:
       additional-pattern-include-list: '@("https://raw.githubusercontent.com/Lombiq/GitHub-Actions/(?<ref>[\w\./-]*)/.github")'
     secrets:

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -77,7 +77,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout Repository
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.TAG_VERSION_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
           "tagname=$tagname" >> $Env:GITHUB_OUTPUT
 
       - name: Set Ref for GitHub Actions and Workflows
-        uses: Lombiq/GitHub-Actions/.github/actions/set-gha-refs@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/set-gha-refs@issue/OSOE-1252
         with:
           path-include-list: ${{ inputs.path-include-list }}
           file-include-list: ${{ inputs.file-include-list }}
@@ -109,7 +109,7 @@ jobs:
         run: git push --tags --force
 
       - name: Create Release
-        uses: Lombiq/GitHub-Actions/.github/actions/release-action@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/release-action@issue/OSOE-1252
         # This is to prevent creating releases when pushing tags for issue-specific pre-releases like
         # v4.3.1-alpha.osoe-86.
         if: "!contains(steps.determine-tag.outputs.tagname, '-')"

--- a/.github/workflows/test-analysis-failure.yml
+++ b/.github/workflows/test-analysis-failure.yml
@@ -91,27 +91,27 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-dotnet@issue/OSOE-1252
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
 
       - name: Set up Node.js
-        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/setup-node@issue/OSOE-1252
         with:
           node-version: ${{ inputs.node-version }}
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Enable Node corepack
         if: inputs.enable-corepack == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/enable-corepack@issue/OSOE-1252
 
       - name: Build and Static Code Analysis
-        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/build-dotnet@issue/OSOE-1252
         with:
           directory: ${{ inputs.build-directory }}
           verbosity: quiet
@@ -123,6 +123,6 @@ jobs:
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -83,7 +83,7 @@ on:
 jobs:
   validate-nuget-publish:
     name: Validate NuGet Publish
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-1252
     with:
       cancel-workflow-on-failure: ${{ inputs.cancel-workflow-on-failure }}
       verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - name: Update GitHub issue and Pull Request
         if: (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') && github.event.action == 'opened'
-        uses: Lombiq/GitHub-Actions/.github/actions/update-github-issue-and-pull-request@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/update-github-issue-and-pull-request@issue/OSOE-1252
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for Merge Conflict in PR
-        uses: Lombiq/GitHub-Actions/.github/actions/check-merge-conflict@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/check-merge-conflict@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-submodule-pull-request.yml
+++ b/.github/workflows/validate-submodule-pull-request.yml
@@ -34,14 +34,14 @@ jobs:
     steps:
       - name: Update GitHub issue and Pull Request
         if: (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') && github.event.action == 'opened'
-        uses: Lombiq/GitHub-Actions/.github/actions/update-github-issue-and-pull-request@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/update-github-issue-and-pull-request@issue/OSOE-1252
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure Parent PR Exists
         if: github.event.pull_request != '' && !startsWith(github.head_ref, 'renovate')
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-submodule-pull-request@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-submodule-pull-request@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.PARENT_TOKEN != '' && secrets.PARENT_TOKEN || secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/validate-this-gha-refs.yml
+++ b/.github/workflows/validate-this-gha-refs.yml
@@ -18,18 +18,18 @@ jobs:
           github.event_name == 'pull_request' ||
           (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
           github.event_name == 'merge_group'
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           fetch-depth: 0
 
       - name: Checkout Repository (Push)
         if: github.event_name == 'push'
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
 
       - name: Check Merge Queue Adds
         id: check-merge-queue-adds
         if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
-        uses: Lombiq/GitHub-Actions/.github/actions/check-merge-queue-adds@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/check-merge-queue-adds@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -54,7 +54,7 @@ jobs:
           github.event_name == 'pull_request' ||
           (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
           github.event_name == 'merge_group'
-        uses: Lombiq/GitHub-Actions/.github/actions/get-changed-files-from-git-diff@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/get-changed-files-from-git-diff@issue/OSOE-1252
         with:
           left-commit: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
           right-commit: ${{ github.sha }}
@@ -66,7 +66,7 @@ jobs:
           github.event_name == 'pull_request' ||
           (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
           github.event_name == 'merge_group'
-        uses: Lombiq/GitHub-Actions/.github/actions/get-changed-gha-items@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/get-changed-gha-items@issue/OSOE-1252
         with:
           file-include-list: ${{ steps.git-diff.outputs.changed-files }}
 
@@ -88,7 +88,7 @@ jobs:
       - name: Check PR Reviews
         id: check-pr-reviews
         if: github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
-        uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-reviews@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/check-pull-request-reviews@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -138,11 +138,11 @@ jobs:
           (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
           github.event_name == 'merge_group') &&
           steps.add-prefix.outputs.prefixed-files != '@()'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@issue/OSOE-1252
         with:
           called-repo-base-include-list: ${{ steps.add-prefix.outputs.prefixed-files }}
           expected-ref: ${{ steps.determine-ref.outputs.expected-ref }}
 
       - name: Verify GitHub Actions Items Match Expected Ref (Push)
         if: github.event_name == 'push'
-        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/verify-gha-refs@issue/OSOE-1252

--- a/.github/workflows/validate-this-pull-request.yml
+++ b/.github/workflows/validate-this-pull-request.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   validate-pull-request:
-    uses: Lombiq/GitHub-Actions/.github/workflows/validate-submodule-pull-request.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/validate-submodule-pull-request.yml@issue/OSOE-1252

--- a/.github/workflows/yaml-lint-this-repo.yml
+++ b/.github/workflows/yaml-lint-this-repo.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   yaml-linting:
     name: YAML Linting
-    uses: Lombiq/GitHub-Actions/.github/workflows/yaml-lint.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/yaml-lint.yml@issue/OSOE-1252
     with:
       config-file-path: .trunk/configs/.yamllint.yaml
       search-path: .

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -38,18 +38,18 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout
-        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@issue/OSOE-1252
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: YAML Linting
-        uses: Lombiq/GitHub-Actions/.github/actions/yaml-lint@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/yaml-lint@issue/OSOE-1252
         with:
           config-file-path: ${{ inputs.config-file-path }}
           search-path: ${{ inputs.search-path }}
 
       - name: Cancel Workflow on Failure
         if: failure() && inputs.cancel-workflow-on-failure == 'true'
-        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/cancel-workflow@issue/OSOE-1252
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## [OSOE-1252](https://lombiq.atlassian.net/browse/OSOE-1252): Renovate Dependency Updates

Merges Renovate branches + temporary GHA ref updates:
- **renovate/all-dependencies**: WarpBuilds/cache v1.4.7 → v1.4.10, renovatebot/github-action v46.1.5 → v46.1.6, azure/webapps-deploy v3.0.7 → v3.0.8
- **renovate/lock-file-maintenance-all-dependencies**: asset-lint CSS/JS/MD package-lock.json refreshes
- **GHA ref updates**: Temporarily changed @dev → @issue/[OSOE-1252](https://lombiq.atlassian.net/browse/OSOE-1252) for CI resolution (will be reverted on merge)

[OSOE-1252]: https://lombiq.atlassian.net/browse/OSOE-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSOE-1252]: https://lombiq.atlassian.net/browse/OSOE-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ