### PR TITLE
OSOE-1149: Only allow publishing a major release via `publish-nuget` if CompatibilitySuppressions files are present in Lombiq.GitHub.Actions

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -141,7 +141,8 @@ runs:
 
         if ('${{ inputs.require-major-version-for-compatibility-suppressions }}' -eq 'true' -and -not $isPreReleaseVersion)
         {
-            $compatibilitySuppressionsFiles = @(Get-ChildItem -Path . -Recurse -File -Filter CompatibilitySuppressions.xml -ErrorAction SilentlyContinue)
+            $compatibilitySuppressionsFiles = @(
+                Get-ChildItem -Path . -Recurse -File -Filter CompatibilitySuppressions.xml -ErrorAction SilentlyContinue)
 
             if ($compatibilitySuppressionsFiles.Count -gt 0)
             {

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -152,17 +152,7 @@ runs:
                 Write-Output 'CompatibilitySuppressions.xml file(s) found:'
                 $compatibilitySuppressionsFiles | ForEach-Object { Write-Output "- $($PSItem.FullName)" }
 
-                $versionMatch = [regex]::Match($version, '^(?<major>\d+)\.\d+\.\d+($|-)')
-                if (-not $versionMatch.Success)
-                {
-                    Write-Output ("::error::CompatibilitySuppressions.xml files indicate breaking changes, but " +
-                        "`"$version`" doesn't use an x.y.z version format. Following Semantic Versioning, publish a " +
-                        'new major version.')
-
-                    exit 1
-                }
-
-                $publishMajorVersion = [int]$versionMatch.Groups['major'].Value
+                $publishMajorVersion = ([Version]$version).Major
 
                 if ($publishMajorVersion -le $current.Major)
                 {

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -144,8 +144,6 @@ runs:
 
         $isPreReleaseVersion = $version -match '^\d+\.\d+\.\d+-(alpha|beta|preview|rc)(\.\d+(\.[a-zA-Z]{2,}(-\d+)?)?)?$'
 
-        Write-OutPut "IsPreReleaseVersion: $isPreReleaseVersion"
-
         if ('${{ inputs.require-major-version-for-compatibility-suppressions }}' -eq 'true' -and -not $isPreReleaseVersion)
         {
             $compatibilitySuppressionsFiles = @(Get-ChildItem -Path . -Recurse -File -Filter CompatibilitySuppressions.xml -ErrorAction SilentlyContinue)
@@ -184,9 +182,6 @@ runs:
 
         Set-GitHubOutput "baseline-version" $baselineVersion
         Set-GitHubOutput "publish-version" $version
-
-        # Only needed for debugging
-        exit 1
 
     # This also implicitly restores NuGet dependencies.
     - name: Add Source Link package

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -33,7 +33,7 @@ inputs:
       version is derived from the latest non-prerelease version tag and the current run number to create a preview
       version (e.g. "1.0.1-preview-1" if the current version is 1.0.0). With "USE_NEXT_PATCH_VERSION" the version is
       derived from the latest non-prerelease version tag to create the next patch version (e.g. "1.0.1" if the current
-      version is 1.0.0). If a literal version is provided, an optional leading `v` is ignored.
+      version is 1.0.0).
   require-major-version-for-compatibility-suppressions:
     required: false
     default: 'true'
@@ -91,11 +91,6 @@ runs:
         $version = @'
         ${{ inputs.publish-version }}
         '@.Trim()
-
-        if ($version -notin @('USE_GITHUB_REF_NAME', 'USE_GITHUB_RUN_NUMBER', 'USE_NEXT_PATCH_VERSION'))
-        {
-            $version = $version.TrimStart('v')
-        }
 
         if ($version -eq 'USE_GITHUB_REF_NAME')
         {
@@ -354,5 +349,4 @@ runs:
       with:
         allowUpdates: true
         generateReleaseNotes: true
-        tag: v${{ steps.setup.outputs.publish-version }}
         artifacts: artifacts/*.nupkg, artifacts/*.snupkg

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -92,10 +92,12 @@ runs:
         ${{ inputs.publish-version }}
         '@.Trim()
 
+        $versionRegex = '^\d+\.\d+\.\d+(-(alpha|beta|preview|rc)(\.\d+(\.[a-zA-Z]{2,}(-\d+)?)?)?)?$'
+
         if ($version -eq 'USE_GITHUB_REF_NAME')
         {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
-            if (!($version -match '^\d+\.\d+\.\d+(-(alpha|beta|preview|rc)(\.\d+(\.[a-zA-Z]{2,}(-\d+)?)?)?)?$'))
+            if (!($version -match $versionRegex))
             {
                 Write-Output ("::error::`"v$version`" is invalid. The correct format is " +
                   "`"vM.N.O`" or `"vM.N.O-[alpha|beta|preview|rc]`" with an optional `".X.<issue-code>`" suffix.")
@@ -137,7 +139,8 @@ runs:
             $baselineVersion = ''
         }
 
-        $isPreReleaseVersion = $version -match '^\d+\.\d+\.\d+-(alpha|beta|preview|rc)(\.\d+(\.[a-zA-Z]{2,}(-\d+)?)?)?$'
+        $version -match $versionRegex
+        $isPreReleaseVersion = $Matches.Values.Count -gt 1
 
         if ('${{ inputs.require-major-version-for-compatibility-suppressions }}' -eq 'true' -and -not $isPreReleaseVersion)
         {

--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -33,7 +33,15 @@ inputs:
       version is derived from the latest non-prerelease version tag and the current run number to create a preview
       version (e.g. "1.0.1-preview-1" if the current version is 1.0.0). With "USE_NEXT_PATCH_VERSION" the version is
       derived from the latest non-prerelease version tag to create the next patch version (e.g. "1.0.1" if the current
-      version is 1.0.0).
+      version is 1.0.0). If a literal version is provided, an optional leading `v` is ignored.
+  require-major-version-for-compatibility-suppressions:
+    required: false
+    default: 'true'
+    description: >
+      If set to "true", publishing fails when any CompatibilitySuppressions.xml file exists in the repository and the
+      publish version's major version is not greater than the latest stable tag's major version. Versions in the format
+      `vM.N.O-[alpha|beta|preview|rc]` with an optional `".X.<issue-code>`" suffix are exempt. Set to "false" for
+      intentional compatibility suppressions that don't require a SemVer major release.
   nuget-artifact-retention-days:
     required: false
     default: '14'
@@ -84,6 +92,11 @@ runs:
         ${{ inputs.publish-version }}
         '@.Trim()
 
+        if ($version -notin @('USE_GITHUB_REF_NAME', 'USE_GITHUB_RUN_NUMBER', 'USE_NEXT_PATCH_VERSION'))
+        {
+            $version = $version.TrimStart('v')
+        }
+
         if ($version -eq 'USE_GITHUB_REF_NAME')
         {
             $version = $Env:GITHUB_REF_NAME.Trim().TrimStart("v")
@@ -129,11 +142,51 @@ runs:
             $baselineVersion = ''
         }
 
+        $isPreReleaseVersion = $version -match '^\d+\.\d+\.\d+-(alpha|beta|preview|rc)(\.\d+(\.[a-zA-Z]{2,}(-\d+)?)?)?$'
+
+        Write-OutPut "IsPreReleaseVersion: $isPreReleaseVersion"
+
+        if ('${{ inputs.require-major-version-for-compatibility-suppressions }}' -eq 'true' -and -not $isPreReleaseVersion)
+        {
+            $compatibilitySuppressionsFiles = @(Get-ChildItem -Path . -Recurse -File -Filter CompatibilitySuppressions.xml -ErrorAction SilentlyContinue)
+
+            if ($compatibilitySuppressionsFiles.Count -gt 0)
+            {
+                Write-Output 'CompatibilitySuppressions.xml file(s) found:'
+                $compatibilitySuppressionsFiles | ForEach-Object { Write-Output "- $($PSItem.FullName)" }
+
+                $versionMatch = [regex]::Match($version, '^(?<major>\d+)\.\d+\.\d+($|-)')
+                if (-not $versionMatch.Success)
+                {
+                    Write-Output ("::error::CompatibilitySuppressions.xml files indicate breaking changes, but " +
+                        "`"$version`" doesn't use an x.y.z version format. Following Semantic Versioning, publish a " +
+                        'new major version.')
+
+                    exit 1
+                }
+
+                $publishMajorVersion = [int]$versionMatch.Groups['major'].Value
+
+                if ($publishMajorVersion -le $current.Major)
+                {
+                    Write-Output ("::error::CompatibilitySuppressions.xml files indicate breaking changes. Following " +
+                        "Semantic Versioning, publish a new major version. The current version is $current, so the " +
+                        "publish version's major version must be greater than $($current.Major), but it is " +
+                        "$publishMajorVersion in `"$version`".")
+
+                    exit 1
+                }
+            }
+        }
+
         Write-Output "Baseline version: $baselineVersion"
         Write-Output "Publish version: $version"
 
         Set-GitHubOutput "baseline-version" $baselineVersion
         Set-GitHubOutput "publish-version" $version
+
+        # Only needed for debugging
+        exit 1
 
     # This also implicitly restores NuGet dependencies.
     - name: Add Source Link package
@@ -306,4 +359,5 @@ runs:
       with:
         allowUpdates: true
         generateReleaseNotes: true
+        tag: v${{ steps.setup.outputs.publish-version }}
         artifacts: artifacts/*.nupkg, artifacts/*.snupkg

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -32,12 +32,6 @@ on:
         type: string
         default: https://api.nuget.org/v3/index.json
         description: The NuGet server URL used by the `dotnet nuget push` command's `--source` argument.
-      checkout-ref:
-        type: string
-        default: ''
-        description: >
-          The branch, tag, or SHA to check out before publishing. This is useful for `workflow_dispatch`-triggered
-          one-off publishes where the package should be built from a specific tag.
       verbosity:
         type: string
         default: minimal
@@ -93,7 +87,7 @@ on:
           version is derived from the latest non-prerelease version tag and the current run number to create a preview
           version (e.g. "1.0.1-preview-1" if the current version is 1.0.0). With "USE_NEXT_PATCH_VERSION" the version is
           derived from the latest non-prerelease version tag to create the next patch version (e.g. "1.0.1" if the current
-          version is 1.0.0). If a literal version is provided, an optional leading `v` is ignored.
+          version is 1.0.0).
       require-major-version-for-compatibility-suppressions:
         type: string
         default: 'true'
@@ -147,7 +141,6 @@ jobs:
       - name: Checkout
         uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
         with:
-          ref: ${{ inputs.checkout-ref }}
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -155,7 +155,7 @@ jobs:
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-1149
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -32,6 +32,12 @@ on:
         type: string
         default: https://api.nuget.org/v3/index.json
         description: The NuGet server URL used by the `dotnet nuget push` command's `--source` argument.
+      checkout-ref:
+        type: string
+        default: ''
+        description: >
+          The branch, tag, or SHA to check out before publishing. This is useful for `workflow_dispatch`-triggered
+          one-off publishes where the package should be built from a specific tag.
       verbosity:
         type: string
         default: minimal
@@ -87,7 +93,15 @@ on:
           version is derived from the latest non-prerelease version tag and the current run number to create a preview
           version (e.g. "1.0.1-preview-1" if the current version is 1.0.0). With "USE_NEXT_PATCH_VERSION" the version is
           derived from the latest non-prerelease version tag to create the next patch version (e.g. "1.0.1" if the current
-          version is 1.0.0).
+          version is 1.0.0). If a literal version is provided, an optional leading `v` is ignored.
+      require-major-version-for-compatibility-suppressions:
+        type: string
+        default: 'true'
+        description: >
+          If set to "true", publishing fails when any CompatibilitySuppressions.xml file exists in the repository and the
+          publish version's major version is not greater than the latest stable tag's major version. Versions in the
+          format `vM.N.O-[alpha|beta|preview|rc]` with an optional `".X.<issue-code>`" suffix are exempt. Set to
+          "false" for intentional compatibility suppressions that don't require a SemVer major release.
       nuget-artifact-retention-days:
         type: string
         default: '14'
@@ -133,6 +147,7 @@ jobs:
       - name: Checkout
         uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
         with:
+          ref: ${{ inputs.checkout-ref }}
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: Set up .NET
@@ -147,7 +162,7 @@ jobs:
           package-manager-cache: ${{ inputs.node-package-manager-cache }}
 
       - name: Publish to NuGet
-        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/publish-nuget@issue/OSOE-1149
         with:
           source: ${{ inputs.source }}
           verbosity: ${{ inputs.verbosity }}
@@ -155,6 +170,7 @@ jobs:
           dotnet-pack-ignore-warning: ${{ inputs.dotnet-pack-ignore-warning }}
           dotnet-pack-include-symbols: ${{ inputs.dotnet-pack-include-symbols }}
           publish-version: ${{ inputs.publish-version }}
+          require-major-version-for-compatibility-suppressions: ${{ inputs.require-major-version-for-compatibility-suppressions }}
           nuget-artifact-retention-days: ${{ inputs.nuget-artifact-retention-days }}
           add-source-link-package: ${{ inputs.add-source-link-package }}
           dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -92,7 +92,7 @@ on:
 jobs:
   validate-nuget-publish:
     name: Validate NuGet Publish
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-1149
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
     with:
       cancel-workflow-on-failure: ${{ inputs.cancel-workflow-on-failure }}
       verbosity: ${{ inputs.verbosity }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -79,11 +79,19 @@ on:
         description: |
           When set to 'true', failed package validation against the baseline will mark the pull request with a title
           suffix, a breaking-changes label, and a guidance comment.
+      require-major-version-for-compatibility-suppressions:
+        type: string
+        default: 'true'
+        description: >
+          If set to "true", publishing validation fails when any CompatibilitySuppressions.xml file exists in the
+          repository and the validation version's major version is not greater than the latest stable tag's major version.
+          Versions in the format `vM.N.O-[alpha|beta|preview|rc]` with an optional `".X.<issue-code>`" suffix are
+          exempt. Set to "false" for intentional compatibility suppressions that don't require a SemVer major release.
 
 jobs:
   validate-nuget-publish:
     name: Validate NuGet Publish
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-1149
     with:
       cancel-workflow-on-failure: ${{ inputs.cancel-workflow-on-failure }}
       verbosity: ${{ inputs.verbosity }}
@@ -98,6 +106,7 @@ jobs:
       dotnet-pack-ignore-warning: ${{ inputs.dotnet-pack-ignore-warning }}%3BNU5104
       dotnet-pack-include-symbols: ${{ inputs.dotnet-pack-include-symbols }}
       publish-version: USE_NEXT_PATCH_VERSION
+      require-major-version-for-compatibility-suppressions: ${{ inputs.require-major-version-for-compatibility-suppressions }}
       nuget-artifact-retention-days: ${{ inputs.nuget-artifact-retention-days }}
       add-source-link-package: ${{ inputs.add-source-link-package }}
       dry-run: true

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -81,12 +81,13 @@ on:
           suffix, a breaking-changes label, and a guidance comment.
       require-major-version-for-compatibility-suppressions:
         type: string
-        default: 'true'
+        default: 'false'
         description: >
           If set to "true", publishing validation fails when any CompatibilitySuppressions.xml file exists in the
           repository and the validation version's major version is not greater than the latest stable tag's major version.
           Versions in the format `vM.N.O-[alpha|beta|preview|rc]` with an optional `".X.<issue-code>`" suffix are
           exempt. Set to "false" for intentional compatibility suppressions that don't require a SemVer major release.
+          Default is set to 'false' otherwise the validation will fail, because the version is defined automatically.
 
 jobs:
   validate-nuget-publish:

--- a/Docs/Workflows/Productivity/PublishNuGetPackage.md
+++ b/Docs/Workflows/Productivity/PublishNuGetPackage.md
@@ -40,6 +40,8 @@ When `source` is not provided, it assumes a default value of pushing to the [Lom
 
 Valid values for `verbosity` are those defined by [MSBuild](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022#:~:text=you%20can%20specify%20the%20following%20verbosity%20levels). The default value is `minimal`.
 
+If any `CompatibilitySuppressions.xml` file exists in the repository, publishing is allowed only when the publish version's major version is greater than the latest stable tag's major version. This follows Semantic Versioning, because compatibility suppressions indicate breaking changes. Versions in the format `vM.N.O-[alpha|beta|preview|rc]` with an optional `".X.<issue-code>`" suffix are exempt from this check. To intentionally bypass it for exceptional cases, set `require-major-version-for-compatibility-suppressions: 'false'`.
+
  Things to keep in mind:
 
 - If you have multiple projects in the repository or if the project you want to build is in a subfolder, then add a solution to the root of the repository that references all projects you want to build.

--- a/Docs/Workflows/Productivity/ValidateNugetPublish.md
+++ b/Docs/Workflows/Productivity/ValidateNugetPublish.md
@@ -20,5 +20,3 @@ jobs:
 The workflow otherwise takes the same configuration options as [`publish-nuget`](PublishNuGetPackage.md), but doesn't require the `API_KEY` secret.
 
 Unless you set `indicate-breaking-changes: 'false'`, failed package validation against the baseline will add the `breaking-changes` label, append "(⚠️ breaking changes)" to the pull request title, and post guidance in a comment. The marker and label are removed automatically if you add the `ignore-breaking-changes` label.
-
-If you add a generated `CompatibilitySuppressions.xml` file to the project, then [`publish-nuget`](PublishNuGetPackage.md) will require the next non-prerelease publish to use a new major version, unless `require-major-version-for-compatibility-suppressions` is set to `'false'`.

--- a/Docs/Workflows/Productivity/ValidateNugetPublish.md
+++ b/Docs/Workflows/Productivity/ValidateNugetPublish.md
@@ -20,3 +20,5 @@ jobs:
 The workflow otherwise takes the same configuration options as [`publish-nuget`](PublishNuGetPackage.md), but doesn't require the `API_KEY` secret.
 
 Unless you set `indicate-breaking-changes: 'false'`, failed package validation against the baseline will add the `breaking-changes` label, append "(⚠️ breaking changes)" to the pull request title, and post guidance in a comment. The marker and label are removed automatically if you add the `ignore-breaking-changes` label.
+
+If you add a generated `CompatibilitySuppressions.xml` file to the project, then [`publish-nuget`](PublishNuGetPackage.md) will require the next non-prerelease publish to use a new major version, unless `require-major-version-for-compatibility-suppressions` is set to `'false'`.


### PR DESCRIPTION
[OSOE-1149](https://lombiq.atlassian.net/browse/OSOE-1149)
Fixes #500

Expected fail: https://github.com/Lombiq/Hosting-Media-Theme/actions/runs/25491487726/job/74800367839
Expected pass with override: https://github.com/Lombiq/Hosting-Media-Theme/actions/runs/25491668856/job/74800976068
Both in test PR: https://github.com/Lombiq/Hosting-Media-Theme/pull/109

[OSOE-1149]: https://lombiq.atlassian.net/browse/OSOE-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ